### PR TITLE
feat:Add inactive_timeout to updateEndpoint, CreateEndpointRequest schemas

### DIFF
--- a/src/libs/Together/Generated/Together.EndpointsClient.CreateEndpoint.g.cs
+++ b/src/libs/Together/Generated/Together.EndpointsClient.CreateEndpoint.g.cs
@@ -245,6 +245,10 @@ namespace Together
         /// The hardware configuration to use for this endpoint<br/>
         /// Example: 1x_nvidia_a100_80gb_sxm
         /// </param>
+        /// <param name="inactiveTimeout">
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to null, omit or set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </param>
         /// <param name="model">
         /// The model to deploy on this endpoint<br/>
         /// Example: meta-llama/Llama-3-8b-chat-hf
@@ -263,6 +267,7 @@ namespace Together
             bool? disablePromptCache = default,
             bool? disableSpeculativeDecoding = default,
             string? displayName = default,
+            int? inactiveTimeout = default,
             global::Together.CreateEndpointRequestState? state = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
@@ -273,6 +278,7 @@ namespace Together
                 DisableSpeculativeDecoding = disableSpeculativeDecoding,
                 DisplayName = displayName,
                 Hardware = hardware,
+                InactiveTimeout = inactiveTimeout,
                 Model = model,
                 State = state,
             };

--- a/src/libs/Together/Generated/Together.EndpointsClient.UpdateEndpoint.g.cs
+++ b/src/libs/Together/Generated/Together.EndpointsClient.UpdateEndpoint.g.cs
@@ -268,6 +268,10 @@ namespace Together
         /// A human-readable name for the endpoint<br/>
         /// Example: My Llama3 70b endpoint
         /// </param>
+        /// <param name="inactiveTimeout">
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </param>
         /// <param name="state">
         /// The desired state of the endpoint<br/>
         /// Example: STARTED
@@ -278,6 +282,7 @@ namespace Together
             string endpointId,
             global::Together.Autoscaling? autoscaling = default,
             string? displayName = default,
+            int? inactiveTimeout = default,
             global::Together.UpdateEndpointRequestState? state = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
@@ -285,6 +290,7 @@ namespace Together
             {
                 Autoscaling = autoscaling,
                 DisplayName = displayName,
+                InactiveTimeout = inactiveTimeout,
                 State = state,
             };
 

--- a/src/libs/Together/Generated/Together.IEndpointsClient.CreateEndpoint.g.cs
+++ b/src/libs/Together/Generated/Together.IEndpointsClient.CreateEndpoint.g.cs
@@ -38,6 +38,10 @@ namespace Together
         /// The hardware configuration to use for this endpoint<br/>
         /// Example: 1x_nvidia_a100_80gb_sxm
         /// </param>
+        /// <param name="inactiveTimeout">
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to null, omit or set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </param>
         /// <param name="model">
         /// The model to deploy on this endpoint<br/>
         /// Example: meta-llama/Llama-3-8b-chat-hf
@@ -56,6 +60,7 @@ namespace Together
             bool? disablePromptCache = default,
             bool? disableSpeculativeDecoding = default,
             string? displayName = default,
+            int? inactiveTimeout = default,
             global::Together.CreateEndpointRequestState? state = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libs/Together/Generated/Together.IEndpointsClient.UpdateEndpoint.g.cs
+++ b/src/libs/Together/Generated/Together.IEndpointsClient.UpdateEndpoint.g.cs
@@ -29,6 +29,10 @@ namespace Together
         /// A human-readable name for the endpoint<br/>
         /// Example: My Llama3 70b endpoint
         /// </param>
+        /// <param name="inactiveTimeout">
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </param>
         /// <param name="state">
         /// The desired state of the endpoint<br/>
         /// Example: STARTED
@@ -39,6 +43,7 @@ namespace Together
             string endpointId,
             global::Together.Autoscaling? autoscaling = default,
             string? displayName = default,
+            int? inactiveTimeout = default,
             global::Together.UpdateEndpointRequestState? state = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libs/Together/Generated/Together.Models.CreateEndpointRequest.g.cs
+++ b/src/libs/Together/Generated/Together.Models.CreateEndpointRequest.g.cs
@@ -47,6 +47,14 @@ namespace Together
         public required string Hardware { get; set; }
 
         /// <summary>
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to null, omit or set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </summary>
+        /// <example>60</example>
+        [global::System.Text.Json.Serialization.JsonPropertyName("inactive_timeout")]
+        public int? InactiveTimeout { get; set; }
+
+        /// <summary>
         /// The model to deploy on this endpoint<br/>
         /// Example: meta-llama/Llama-3-8b-chat-hf
         /// </summary>
@@ -93,6 +101,10 @@ namespace Together
         /// The hardware configuration to use for this endpoint<br/>
         /// Example: 1x_nvidia_a100_80gb_sxm
         /// </param>
+        /// <param name="inactiveTimeout">
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to null, omit or set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </param>
         /// <param name="model">
         /// The model to deploy on this endpoint<br/>
         /// Example: meta-llama/Llama-3-8b-chat-hf
@@ -112,6 +124,7 @@ namespace Together
             bool? disablePromptCache,
             bool? disableSpeculativeDecoding,
             string? displayName,
+            int? inactiveTimeout,
             global::Together.CreateEndpointRequestState? state)
         {
             this.Autoscaling = autoscaling ?? throw new global::System.ArgumentNullException(nameof(autoscaling));
@@ -120,6 +133,7 @@ namespace Together
             this.DisablePromptCache = disablePromptCache;
             this.DisableSpeculativeDecoding = disableSpeculativeDecoding;
             this.DisplayName = displayName;
+            this.InactiveTimeout = inactiveTimeout;
             this.State = state;
         }
 

--- a/src/libs/Together/Generated/Together.Models.UpdateEndpointRequest.g.cs
+++ b/src/libs/Together/Generated/Together.Models.UpdateEndpointRequest.g.cs
@@ -23,6 +23,14 @@ namespace Together
         public string? DisplayName { get; set; }
 
         /// <summary>
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </summary>
+        /// <example>60</example>
+        [global::System.Text.Json.Serialization.JsonPropertyName("inactive_timeout")]
+        public int? InactiveTimeout { get; set; }
+
+        /// <summary>
         /// The desired state of the endpoint<br/>
         /// Example: STARTED
         /// </summary>
@@ -47,6 +55,10 @@ namespace Together
         /// A human-readable name for the endpoint<br/>
         /// Example: My Llama3 70b endpoint
         /// </param>
+        /// <param name="inactiveTimeout">
+        /// The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.<br/>
+        /// Example: 60
+        /// </param>
         /// <param name="state">
         /// The desired state of the endpoint<br/>
         /// Example: STARTED
@@ -57,10 +69,12 @@ namespace Together
         public UpdateEndpointRequest(
             global::Together.Autoscaling? autoscaling,
             string? displayName,
+            int? inactiveTimeout,
             global::Together.UpdateEndpointRequestState? state)
         {
             this.Autoscaling = autoscaling;
             this.DisplayName = displayName;
+            this.InactiveTimeout = inactiveTimeout;
             this.State = state;
         }
 

--- a/src/libs/Together/openapi.yaml
+++ b/src/libs/Together/openapi.yaml
@@ -417,6 +417,11 @@ paths:
                   type: string
                   description: A human-readable name for the endpoint
                   example: My Llama3 70b endpoint
+                inactive_timeout:
+                  type: integer
+                  description: The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.
+                  nullable: true
+                  example: 60
                 state:
                   enum:
                     - STARTED
@@ -1870,6 +1875,11 @@ components:
           type: string
           description: The hardware configuration to use for this endpoint
           example: 1x_nvidia_a100_80gb_sxm
+        inactive_timeout:
+          type: integer
+          description: 'The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to null, omit or set to 0 to disable automatic timeout.'
+          nullable: true
+          example: 60
         model:
           type: string
           description: The model to deploy on this endpoint


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new inactivity timeout option for endpoint management. Users can now specify the number of minutes an endpoint remains idle before automatic shutdown, with the flexibility to disable this behavior by setting the timeout to 0. This functionality is available during both endpoint creation and update, offering enhanced control over resource lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->