### PR TITLE
feat:Rename image generation request body property from guidance to guidance_scale

### DIFF
--- a/src/libs/Together/Generated/Together.IImagesClient.CreateImagesGenerations.g.cs
+++ b/src/libs/Together/Generated/Together.IImagesClient.CreateImagesGenerations.g.cs
@@ -19,7 +19,7 @@ namespace Together
         /// Create image<br/>
         /// Use an image model to generate an image for a given prompt.
         /// </summary>
-        /// <param name="guidance">
+        /// <param name="guidanceScale">
         /// Adjusts the alignment of the generated image with the input prompt. Higher values (e.g., 8-10) make the output more faithful to the prompt, while lower values (e.g., 1-5) encourage more creative freedom.<br/>
         /// Default Value: 3.5
         /// </param>
@@ -71,7 +71,7 @@ namespace Together
         global::System.Threading.Tasks.Task<global::Together.ImageResponse> CreateImagesGenerationsAsync(
             global::Together.AnyOf<global::Together.RequestModel?, string> model,
             string prompt,
-            double? guidance = default,
+            double? guidanceScale = default,
             int? height = default,
             global::System.Collections.Generic.IList<global::Together.RequestImageLora>? imageLoras = default,
             string? imageUrl = default,

--- a/src/libs/Together/Generated/Together.ImagesClient.CreateImagesGenerations.g.cs
+++ b/src/libs/Together/Generated/Together.ImagesClient.CreateImagesGenerations.g.cs
@@ -170,7 +170,7 @@ namespace Together
         /// Create image<br/>
         /// Use an image model to generate an image for a given prompt.
         /// </summary>
-        /// <param name="guidance">
+        /// <param name="guidanceScale">
         /// Adjusts the alignment of the generated image with the input prompt. Higher values (e.g., 8-10) make the output more faithful to the prompt, while lower values (e.g., 1-5) encourage more creative freedom.<br/>
         /// Default Value: 3.5
         /// </param>
@@ -222,7 +222,7 @@ namespace Together
         public async global::System.Threading.Tasks.Task<global::Together.ImageResponse> CreateImagesGenerationsAsync(
             global::Together.AnyOf<global::Together.RequestModel?, string> model,
             string prompt,
-            double? guidance = default,
+            double? guidanceScale = default,
             int? height = default,
             global::System.Collections.Generic.IList<global::Together.RequestImageLora>? imageLoras = default,
             string? imageUrl = default,
@@ -237,7 +237,7 @@ namespace Together
         {
             var __request = new global::Together.Request3
             {
-                Guidance = guidance,
+                GuidanceScale = guidanceScale,
                 Height = height,
                 ImageLoras = imageLoras,
                 ImageUrl = imageUrl,

--- a/src/libs/Together/Generated/Together.Models.Request3.g.cs
+++ b/src/libs/Together/Generated/Together.Models.Request3.g.cs
@@ -14,8 +14,8 @@ namespace Together
         /// Adjusts the alignment of the generated image with the input prompt. Higher values (e.g., 8-10) make the output more faithful to the prompt, while lower values (e.g., 1-5) encourage more creative freedom.<br/>
         /// Default Value: 3.5
         /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("guidance")]
-        public double? Guidance { get; set; }
+        [global::System.Text.Json.Serialization.JsonPropertyName("guidance_scale")]
+        public double? GuidanceScale { get; set; }
 
         /// <summary>
         /// Height of the image to generate in number of pixels.<br/>
@@ -112,7 +112,7 @@ namespace Together
         /// <summary>
         /// Initializes a new instance of the <see cref="Request3" /> class.
         /// </summary>
-        /// <param name="guidance">
+        /// <param name="guidanceScale">
         /// Adjusts the alignment of the generated image with the input prompt. Higher values (e.g., 8-10) make the output more faithful to the prompt, while lower values (e.g., 1-5) encourage more creative freedom.<br/>
         /// Default Value: 3.5
         /// </param>
@@ -165,7 +165,7 @@ namespace Together
         public Request3(
             global::Together.AnyOf<global::Together.RequestModel?, string> model,
             string prompt,
-            double? guidance,
+            double? guidanceScale,
             int? height,
             global::System.Collections.Generic.IList<global::Together.RequestImageLora>? imageLoras,
             string? imageUrl,
@@ -179,7 +179,7 @@ namespace Together
         {
             this.Model = model;
             this.Prompt = prompt ?? throw new global::System.ArgumentNullException(nameof(prompt));
-            this.Guidance = guidance;
+            this.GuidanceScale = guidanceScale;
             this.Height = height;
             this.ImageLoras = imageLoras;
             this.ImageUrl = imageUrl;

--- a/src/libs/Together/openapi.yaml
+++ b/src/libs/Together/openapi.yaml
@@ -1019,7 +1019,7 @@ paths:
                 - model
               type: object
               properties:
-                guidance:
+                guidance_scale:
                   type: number
                   description: 'Adjusts the alignment of the generated image with the input prompt. Higher values (e.g., 8-10) make the output more faithful to the prompt, while lower values (e.g., 1-5) encourage more creative freedom.'
                   default: 3.5


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the image generation endpoint to use the parameter name guidance_scale instead of guidance for controlling how closely generated images match the input prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->