### PR TITLE
feat:Remove tokens property from AudioTranscriptionSegment schema in OpenAPI

### DIFF
--- a/src/libs/Together/Generated/Together.JsonSerializerContextTypes.g.cs
+++ b/src/libs/Together/Generated/Together.JsonSerializerContextTypes.g.cs
@@ -146,1182 +146,1178 @@ namespace Together
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<int>? Type30 { get; set; }
+        public global::Together.AudioTranscriptionVerboseJsonResponseTask? Type30 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionVerboseJsonResponseTask? Type31 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionWord>? Type31 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionWord>? Type32 { get; set; }
+        public global::Together.AudioTranscriptionWord? Type32 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionWord? Type33 { get; set; }
+        public global::Together.AudioTranslationJsonResponse? Type33 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationJsonResponse? Type34 { get; set; }
+        public global::Together.AudioTranslationRequest? Type34 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequest? Type35 { get; set; }
+        public global::Together.AudioTranslationRequestModel? Type35 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequestModel? Type36 { get; set; }
+        public global::Together.AudioTranslationRequestResponseFormat? Type36 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequestResponseFormat? Type37 { get; set; }
+        public global::Together.AudioTranslationRequestTimestampGranularities? Type37 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequestTimestampGranularities? Type38 { get; set; }
+        public global::Together.AudioTranslationResponse? Type38 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationResponse? Type39 { get; set; }
+        public global::Together.AudioTranslationVerboseJsonResponse? Type39 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationVerboseJsonResponse? Type40 { get; set; }
+        public global::Together.AudioTranslationVerboseJsonResponseTask? Type40 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationVerboseJsonResponseTask? Type41 { get; set; }
+        public global::Together.Autoscaling? Type41 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Autoscaling? Type42 { get; set; }
+        public global::Together.BatchErrorResponse? Type42 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchErrorResponse? Type43 { get; set; }
+        public global::Together.BatchJob? Type43 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchJob? Type44 { get; set; }
+        public global::System.DateTime? Type44 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.DateTime? Type45 { get; set; }
+        public long? Type45 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public long? Type46 { get; set; }
+        public global::System.Guid? Type46 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Guid? Type47 { get; set; }
+        public global::Together.BatchJobStatus? Type47 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchJobStatus? Type48 { get; set; }
+        public global::Together.BatchJobWithWarning? Type48 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchJobWithWarning? Type49 { get; set; }
+        public global::Together.ChatCompletionAssistantMessageParam? Type49 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionAssistantMessageParam? Type50 { get; set; }
+        public global::Together.ChatCompletionAssistantMessageParamFunctionCall? Type50 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionAssistantMessageParamFunctionCall? Type51 { get; set; }
+        public global::Together.ChatCompletionAssistantMessageParamRole? Type51 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionAssistantMessageParamRole? Type52 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ToolChoice2>? Type52 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ToolChoice2>? Type53 { get; set; }
+        public global::Together.ToolChoice2? Type53 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolChoice2? Type54 { get; set; }
+        public global::Together.ToolChoiceFunction? Type54 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolChoiceFunction? Type55 { get; set; }
+        public global::Together.ToolChoiceType? Type55 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolChoiceType? Type56 { get; set; }
+        public global::Together.ChatCompletionChoice? Type56 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoice? Type57 { get; set; }
+        public global::Together.ChatCompletionChoiceDelta? Type57 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoiceDelta? Type58 { get; set; }
+        public global::Together.ChatCompletionChoiceDeltaFunctionCall? Type58 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoiceDeltaFunctionCall? Type59 { get; set; }
+        public global::Together.ChatCompletionChoiceDeltaRole? Type59 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoiceDeltaRole? Type60 { get; set; }
+        public global::Together.FinishReason? Type60 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinishReason? Type61 { get; set; }
+        public global::Together.LogprobsPart? Type61 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LogprobsPart? Type62 { get; set; }
+        public global::System.Collections.Generic.IList<double>? Type62 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<double>? Type63 { get; set; }
+        public global::System.Collections.Generic.IList<string>? Type63 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<string>? Type64 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChoicesDataItem>? Type64 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChoicesDataItem>? Type65 { get; set; }
+        public global::Together.ChatCompletionChoicesDataItem? Type65 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoicesDataItem? Type66 { get; set; }
+        public global::Together.ChatCompletionMessage? Type66 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessage? Type67 { get; set; }
+        public global::Together.ChatCompletionMessageFunctionCall? Type67 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessageFunctionCall? Type68 { get; set; }
+        public global::Together.ChatCompletionMessageRole? Type68 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessageRole? Type69 { get; set; }
+        public global::Together.ChatCompletionChunk? Type69 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunk? Type70 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChunkChoice>? Type70 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChunkChoice>? Type71 { get; set; }
+        public global::Together.ChatCompletionChunkChoice? Type71 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoice? Type72 { get; set; }
+        public global::Together.ChatCompletionChunkChoiceDelta? Type72 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoiceDelta? Type73 { get; set; }
+        public global::Together.ChatCompletionChunkChoiceDeltaFunctionCall? Type73 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoiceDeltaFunctionCall? Type74 { get; set; }
+        public global::Together.ChatCompletionChunkChoiceDeltaRole? Type74 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoiceDeltaRole? Type75 { get; set; }
+        public global::Together.ChatCompletionChunkObject? Type75 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkObject? Type76 { get; set; }
+        public global::Together.UsageData? Type76 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.UsageData? Type77 { get; set; }
+        public global::Together.ChatCompletionEvent? Type77 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionEvent? Type78 { get; set; }
+        public global::Together.ChatCompletionFunctionMessageParam? Type78 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionFunctionMessageParam? Type79 { get; set; }
+        public global::Together.ChatCompletionFunctionMessageParamRole? Type79 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionFunctionMessageParamRole? Type80 { get; set; }
+        public global::Together.ChatCompletionMessageParam? Type80 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessageParam? Type81 { get; set; }
+        public global::Together.ChatCompletionSystemMessageParam? Type81 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionSystemMessageParam? Type82 { get; set; }
+        public global::Together.ChatCompletionSystemMessageParamRole? Type82 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionSystemMessageParamRole? Type83 { get; set; }
+        public global::Together.ChatCompletionUserMessageParam? Type83 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageParam? Type84 { get; set; }
+        public global::Together.ChatCompletionUserMessageContent? Type84 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContent? Type85 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>>? Type85 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>>? Type86 { get; set; }
+        public global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>? Type86 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>? Type87 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1? Type87 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1? Type88 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1Type? Type88 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1Type? Type89 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2? Type89 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2? Type90 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2ImageUrl? Type90 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2ImageUrl? Type91 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2Type? Type91 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2Type? Type92 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3? Type92 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3? Type93 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3Type? Type93 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3Type? Type94 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3VideoUrl? Type94 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3VideoUrl? Type95 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4? Type95 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4? Type96 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4AudioUrl? Type96 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4AudioUrl? Type97 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4Type? Type97 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4Type? Type98 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5? Type98 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5? Type99 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudio? Type99 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudio? Type100 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudioFormat? Type100 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudioFormat? Type101 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5Type? Type101 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5Type? Type102 { get; set; }
+        public global::Together.ChatCompletionUserMessageParamRole? Type102 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageParamRole? Type103 { get; set; }
+        public global::Together.ChatCompletionToolMessageParam? Type103 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolMessageParam? Type104 { get; set; }
+        public global::Together.ChatCompletionToolMessageParamRole? Type104 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolMessageParamRole? Type105 { get; set; }
+        public global::Together.ChatCompletionRequest? Type105 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequest? Type106 { get; set; }
+        public global::Together.ChatCompletionRequestContextLengthExceededBehavior? Type106 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestContextLengthExceededBehavior? Type107 { get; set; }
+        public global::Together.OneOf<global::Together.ChatCompletionRequestFunctionCallEnum?, global::Together.ChatCompletionRequestFunctionCallEnum2>? Type107 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.ChatCompletionRequestFunctionCallEnum?, global::Together.ChatCompletionRequestFunctionCallEnum2>? Type108 { get; set; }
+        public global::Together.ChatCompletionRequestFunctionCallEnum? Type108 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestFunctionCallEnum? Type109 { get; set; }
+        public global::Together.ChatCompletionRequestFunctionCallEnum2? Type109 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestFunctionCallEnum2? Type110 { get; set; }
+        public global::System.Collections.Generic.Dictionary<string, float>? Type110 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.Dictionary<string, float>? Type111 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ChatCompletionMessageParam>? Type111 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ChatCompletionMessageParam>? Type112 { get; set; }
+        public global::Together.AnyOf<global::Together.ChatCompletionRequestModel?, string>? Type112 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.ChatCompletionRequestModel?, string>? Type113 { get; set; }
+        public global::Together.ChatCompletionRequestModel? Type113 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestModel? Type114 { get; set; }
+        public global::Together.ChatCompletionRequestResponseFormat? Type114 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestResponseFormat? Type115 { get; set; }
+        public object? Type115 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public object? Type116 { get; set; }
+        public global::Together.OneOf<string, global::Together.ToolChoice2>? Type116 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<string, global::Together.ToolChoice2>? Type117 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ToolsPart>? Type117 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ToolsPart>? Type118 { get; set; }
+        public global::Together.ToolsPart? Type118 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolsPart? Type119 { get; set; }
+        public global::Together.ToolsPartFunction? Type119 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolsPartFunction? Type120 { get; set; }
+        public global::Together.ChatCompletionResponse? Type120 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionResponse? Type121 { get; set; }
+        public global::Together.ChatCompletionResponseObject? Type121 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionResponseObject? Type122 { get; set; }
+        public global::Together.ChatCompletionStream? Type122 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionStream? Type123 { get; set; }
+        public global::Together.ChatCompletionToken? Type123 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToken? Type124 { get; set; }
+        public global::Together.ChatCompletionTool? Type124 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionTool? Type125 { get; set; }
+        public global::Together.ChatCompletionToolFunction? Type125 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolFunction? Type126 { get; set; }
+        public global::Together.ChatCompletionToolType? Type126 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolType? Type127 { get; set; }
+        public global::Together.CompletionChoice? Type127 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoice? Type128 { get; set; }
+        public global::Together.CompletionChoiceDelta? Type128 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoiceDelta? Type129 { get; set; }
+        public global::Together.CompletionChoiceDeltaFunctionCall? Type129 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoiceDeltaFunctionCall? Type130 { get; set; }
+        public global::Together.CompletionChoiceDeltaRole? Type130 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoiceDeltaRole? Type131 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.CompletionChoicesDataItem>? Type131 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.CompletionChoicesDataItem>? Type132 { get; set; }
+        public global::Together.CompletionChoicesDataItem? Type132 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoicesDataItem? Type133 { get; set; }
+        public global::Together.CompletionChunk? Type133 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChunk? Type134 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.CompletionChoice>? Type134 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.CompletionChoice>? Type135 { get; set; }
+        public global::Together.CompletionChunkObject? Type135 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChunkObject? Type136 { get; set; }
+        public global::Together.CompletionToken? Type136 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionToken? Type137 { get; set; }
+        public global::Together.CompletionEvent? Type137 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionEvent? Type138 { get; set; }
+        public global::Together.CompletionRequest? Type138 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionRequest? Type139 { get; set; }
+        public global::Together.AnyOf<global::Together.CompletionRequestModel?, string>? Type139 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.CompletionRequestModel?, string>? Type140 { get; set; }
+        public global::Together.CompletionRequestModel? Type140 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionRequestModel? Type141 { get; set; }
+        public global::Together.AnyOf<global::Together.CompletionRequestSafetyModel?, string>? Type141 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.CompletionRequestSafetyModel?, string>? Type142 { get; set; }
+        public global::Together.CompletionRequestSafetyModel? Type142 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionRequestSafetyModel? Type143 { get; set; }
+        public global::Together.CompletionResponse? Type143 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionResponse? Type144 { get; set; }
+        public global::Together.CompletionResponseObject? Type144 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionResponseObject? Type145 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.PromptPartItem>? Type145 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.PromptPartItem>? Type146 { get; set; }
+        public global::Together.PromptPartItem? Type146 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.PromptPartItem? Type147 { get; set; }
+        public global::Together.CompletionStream? Type147 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionStream? Type148 { get; set; }
+        public global::Together.CosineLRSchedulerArgs? Type148 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CosineLRSchedulerArgs? Type149 { get; set; }
+        public global::Together.CreateBatchRequest? Type149 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CreateBatchRequest? Type150 { get; set; }
+        public global::Together.CreateEndpointRequest? Type150 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CreateEndpointRequest? Type151 { get; set; }
+        public global::Together.CreateEndpointRequestState? Type151 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CreateEndpointRequestState? Type152 { get; set; }
+        public global::Together.DedicatedEndpoint? Type152 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpoint? Type153 { get; set; }
+        public global::Together.DedicatedEndpointObject? Type153 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpointObject? Type154 { get; set; }
+        public global::Together.DedicatedEndpointState? Type154 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpointState? Type155 { get; set; }
+        public global::Together.DedicatedEndpointType? Type155 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpointType? Type156 { get; set; }
+        public global::Together.DisplayorExecuteOutput? Type156 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DisplayorExecuteOutput? Type157 { get; set; }
+        public global::Together.DisplayorExecuteOutputData? Type157 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DisplayorExecuteOutputData? Type158 { get; set; }
+        public global::Together.DisplayorExecuteOutputType? Type158 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DisplayorExecuteOutputType? Type159 { get; set; }
+        public global::Together.EmbeddingsRequest? Type159 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsRequest? Type160 { get; set; }
+        public global::Together.OneOf<string, global::System.Collections.Generic.IList<string>>? Type160 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<string, global::System.Collections.Generic.IList<string>>? Type161 { get; set; }
+        public global::Together.AnyOf<global::Together.EmbeddingsRequestModel?, string>? Type161 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.EmbeddingsRequestModel?, string>? Type162 { get; set; }
+        public global::Together.EmbeddingsRequestModel? Type162 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsRequestModel? Type163 { get; set; }
+        public global::Together.EmbeddingsResponse? Type163 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponse? Type164 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.EmbeddingsResponseDataItem>? Type164 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.EmbeddingsResponseDataItem>? Type165 { get; set; }
+        public global::Together.EmbeddingsResponseDataItem? Type165 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponseDataItem? Type166 { get; set; }
+        public global::Together.EmbeddingsResponseDataItemObject? Type166 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponseDataItemObject? Type167 { get; set; }
+        public global::Together.EmbeddingsResponseObject? Type167 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponseObject? Type168 { get; set; }
+        public global::Together.EndpointPricing? Type168 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EndpointPricing? Type169 { get; set; }
+        public global::Together.Error? Type169 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Error? Type170 { get; set; }
+        public global::Together.ErrorData? Type170 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorData? Type171 { get; set; }
+        public global::Together.ErrorDataError? Type171 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorDataError? Type172 { get; set; }
+        public global::Together.ErrorOutput? Type172 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorOutput? Type173 { get; set; }
+        public global::Together.ErrorOutputType? Type173 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorOutputType? Type174 { get; set; }
+        public global::Together.ExecuteRequest? Type174 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequest? Type175 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ExecuteRequestFile>? Type175 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ExecuteRequestFile>? Type176 { get; set; }
+        public global::Together.ExecuteRequestFile? Type176 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequestFile? Type177 { get; set; }
+        public global::Together.ExecuteRequestFileEncoding? Type177 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequestFileEncoding? Type178 { get; set; }
+        public global::Together.ExecuteRequestLanguage? Type178 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequestLanguage? Type179 { get; set; }
+        public global::Together.ExecuteResponse? Type179 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponse? Type180 { get; set; }
+        public global::Together.ExecuteResponseVariant1? Type180 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1? Type181 { get; set; }
+        public global::Together.ExecuteResponseVariant1Data? Type181 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1Data? Type182 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.OutputsItem>? Type182 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.OutputsItem>? Type183 { get; set; }
+        public global::Together.OutputsItem? Type183 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OutputsItem? Type184 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant1? Type184 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant1? Type185 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant1Type? Type185 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant1Type? Type186 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant2? Type186 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant2? Type187 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant2Type? Type187 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant2Type? Type188 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant3? Type188 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant3? Type189 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant3Data? Type189 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant3Data? Type190 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant3Type? Type190 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant3Type? Type191 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputDiscriminator? Type191 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputDiscriminator? Type192 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataStatus? Type192 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataStatus? Type193 { get; set; }
+        public global::Together.ExecuteResponseVariant2? Type193 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant2? Type194 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.OneOf<string, object>>? Type194 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.OneOf<string, object>>? Type195 { get; set; }
+        public global::Together.OneOf<string, object>? Type195 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<string, object>? Type196 { get; set; }
+        public global::Together.FileDeleteResponse? Type196 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileDeleteResponse? Type197 { get; set; }
+        public global::Together.FileList? Type197 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileList? Type198 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FileResponse>? Type198 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FileResponse>? Type199 { get; set; }
+        public global::Together.FileResponse? Type199 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileResponse? Type200 { get; set; }
+        public global::Together.FileType? Type200 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileType? Type201 { get; set; }
+        public global::Together.FilePurpose? Type201 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FilePurpose? Type202 { get; set; }
+        public global::Together.FileObject? Type202 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileObject? Type203 { get; set; }
+        public global::Together.FineTuneCheckpoint? Type203 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FineTuneCheckpoint? Type204 { get; set; }
+        public global::Together.FineTuneEvent? Type204 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FineTuneEvent? Type205 { get; set; }
+        public global::Together.FinetuneEventLevels? Type205 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneEventLevels? Type206 { get; set; }
+        public global::Together.FineTuneEventObject? Type206 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FineTuneEventObject? Type207 { get; set; }
+        public global::Together.FinetuneEventType? Type207 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneEventType? Type208 { get; set; }
+        public global::Together.FinetuneDownloadResult? Type208 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneDownloadResult? Type209 { get; set; }
+        public global::Together.FinetuneDownloadResultObject? Type209 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneDownloadResultObject? Type210 { get; set; }
+        public global::Together.FinetuneJobStatus? Type210 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneJobStatus? Type211 { get; set; }
+        public global::Together.FinetuneListCheckpoints? Type211 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneListCheckpoints? Type212 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FineTuneCheckpoint>? Type212 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FineTuneCheckpoint>? Type213 { get; set; }
+        public global::Together.FinetuneListEvents? Type213 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneListEvents? Type214 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FineTuneEvent>? Type214 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FineTuneEvent>? Type215 { get; set; }
+        public global::Together.FinetuneResponse? Type215 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponse? Type216 { get; set; }
+        public global::Together.OneOf<int?, global::Together.FinetuneResponseBatchSize?>? Type216 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<int?, global::Together.FinetuneResponseBatchSize?>? Type217 { get; set; }
+        public global::Together.FinetuneResponseBatchSize? Type217 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponseBatchSize? Type218 { get; set; }
+        public global::Together.LRScheduler? Type218 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LRScheduler? Type219 { get; set; }
+        public global::Together.OneOf<global::Together.LinearLRSchedulerArgs, global::Together.CosineLRSchedulerArgs>? Type219 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.LinearLRSchedulerArgs, global::Together.CosineLRSchedulerArgs>? Type220 { get; set; }
+        public global::Together.LinearLRSchedulerArgs? Type220 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LinearLRSchedulerArgs? Type221 { get; set; }
+        public global::Together.LRSchedulerLrSchedulerType? Type221 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LRSchedulerLrSchedulerType? Type222 { get; set; }
+        public global::Together.OneOf<bool?, global::Together.FinetuneResponseTrainOnInputs?>? Type222 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<bool?, global::Together.FinetuneResponseTrainOnInputs?>? Type223 { get; set; }
+        public global::Together.FinetuneResponseTrainOnInputs? Type223 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponseTrainOnInputs? Type224 { get; set; }
+        public global::Together.OneOf<global::Together.TrainingMethodSFT, global::Together.TrainingMethodDPO>? Type224 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.TrainingMethodSFT, global::Together.TrainingMethodDPO>? Type225 { get; set; }
+        public global::Together.TrainingMethodSFT? Type225 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodSFT? Type226 { get; set; }
+        public global::Together.TrainingMethodSFTMethod? Type226 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodSFTMethod? Type227 { get; set; }
+        public global::Together.OneOf<bool?, global::Together.TrainingMethodSFTTrainOnInputs?>? Type227 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<bool?, global::Together.TrainingMethodSFTTrainOnInputs?>? Type228 { get; set; }
+        public global::Together.TrainingMethodSFTTrainOnInputs? Type228 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodSFTTrainOnInputs? Type229 { get; set; }
+        public global::Together.TrainingMethodDPO? Type229 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodDPO? Type230 { get; set; }
+        public global::Together.TrainingMethodDPOMethod? Type230 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodDPOMethod? Type231 { get; set; }
+        public global::Together.OneOf<global::Together.FullTrainingType, global::Together.LoRATrainingType>? Type231 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.FullTrainingType, global::Together.LoRATrainingType>? Type232 { get; set; }
+        public global::Together.FullTrainingType? Type232 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FullTrainingType? Type233 { get; set; }
+        public global::Together.FullTrainingTypeType? Type233 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FullTrainingTypeType? Type234 { get; set; }
+        public global::Together.LoRATrainingType? Type234 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LoRATrainingType? Type235 { get; set; }
+        public global::Together.LoRATrainingTypeType? Type235 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LoRATrainingTypeType? Type236 { get; set; }
+        public global::Together.FinetuneResponseTruncated? Type236 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponseTruncated? Type237 { get; set; }
+        public global::Together.FinetuneTruncatedList? Type237 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneTruncatedList? Type238 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FinetuneResponseTruncated>? Type238 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FinetuneResponseTruncated>? Type239 { get; set; }
+        public global::Together.HardwareAvailability? Type239 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareAvailability? Type240 { get; set; }
+        public global::Together.HardwareAvailabilityStatus? Type240 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareAvailabilityStatus? Type241 { get; set; }
+        public global::Together.HardwareSpec? Type241 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareSpec? Type242 { get; set; }
+        public global::Together.HardwareWithStatus? Type242 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareWithStatus? Type243 { get; set; }
+        public global::Together.HardwareWithStatusObject? Type243 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareWithStatusObject? Type244 { get; set; }
+        public global::Together.ImageResponse? Type244 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponse? Type245 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.DataItem>? Type245 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.DataItem>? Type246 { get; set; }
+        public global::Together.DataItem? Type246 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DataItem? Type247 { get; set; }
+        public global::Together.ImageResponseDataB64? Type247 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataB64? Type248 { get; set; }
+        public global::Together.ImageResponseDataB64Type? Type248 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataB64Type? Type249 { get; set; }
+        public global::Together.ImageResponseDataUrl? Type249 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataUrl? Type250 { get; set; }
+        public global::Together.ImageResponseDataUrlType? Type250 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataUrlType? Type251 { get; set; }
+        public global::Together.ImageResponseDataItemDiscriminator? Type251 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataItemDiscriminator? Type252 { get; set; }
+        public global::Together.ImageResponseObject? Type252 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseObject? Type253 { get; set; }
+        public global::Together.InterpreterOutput? Type253 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutput? Type254 { get; set; }
+        public global::Together.InterpreterOutputVariant1? Type254 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant1? Type255 { get; set; }
+        public global::Together.InterpreterOutputVariant1Type? Type255 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant1Type? Type256 { get; set; }
+        public global::Together.InterpreterOutputVariant2? Type256 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant2? Type257 { get; set; }
+        public global::Together.InterpreterOutputVariant2Type? Type257 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant2Type? Type258 { get; set; }
+        public global::Together.InterpreterOutputVariant3? Type258 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant3? Type259 { get; set; }
+        public global::Together.InterpreterOutputVariant3Data? Type259 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant3Data? Type260 { get; set; }
+        public global::Together.InterpreterOutputVariant3Type? Type260 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant3Type? Type261 { get; set; }
+        public global::Together.InterpreterOutputDiscriminator? Type261 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputDiscriminator? Type262 { get; set; }
+        public global::Together.JobInfoSuccessResponse? Type262 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponse? Type263 { get; set; }
+        public global::Together.JobInfoSuccessResponseArgs? Type263 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponseArgs? Type264 { get; set; }
+        public global::Together.JobInfoSuccessResponseStatus? Type264 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponseStatus? Type265 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponseStatusUpdate>? Type265 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponseStatusUpdate>? Type266 { get; set; }
+        public global::Together.JobInfoSuccessResponseStatusUpdate? Type266 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponseStatusUpdate? Type267 { get; set; }
+        public global::Together.JobsInfoSuccessResponse? Type267 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobsInfoSuccessResponse? Type268 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponse>? Type268 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponse>? Type269 { get; set; }
+        public global::Together.ListEndpoint? Type269 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpoint? Type270 { get; set; }
+        public global::Together.ListEndpointObject? Type270 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointObject? Type271 { get; set; }
+        public global::Together.ListEndpointState? Type271 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointState? Type272 { get; set; }
+        public global::Together.ListEndpointType? Type272 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointType? Type273 { get; set; }
+        public global::Together.ModelInfo? Type273 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelInfo? Type274 { get; set; }
+        public global::Together.Pricing? Type274 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Pricing? Type275 { get; set; }
+        public global::Together.ModelInfoType? Type275 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelInfoType? Type276 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ModelInfo>? Type276 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ModelInfo>? Type277 { get; set; }
+        public global::Together.ModelUploadRequest? Type277 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadRequest? Type278 { get; set; }
+        public global::Together.ModelUploadRequestModelType? Type278 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadRequestModelType? Type279 { get; set; }
+        public global::Together.ModelUploadSuccessResponse? Type279 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadSuccessResponse? Type280 { get; set; }
+        public global::Together.ModelUploadSuccessResponseData? Type280 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadSuccessResponseData? Type281 { get; set; }
+        public global::Together.RerankRequest? Type281 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankRequest? Type282 { get; set; }
+        public global::Together.OneOf<global::System.Collections.Generic.IList<object>, global::System.Collections.Generic.IList<string>>? Type282 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::System.Collections.Generic.IList<object>, global::System.Collections.Generic.IList<string>>? Type283 { get; set; }
+        public global::System.Collections.Generic.IList<object>? Type283 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<object>? Type284 { get; set; }
+        public global::Together.AnyOf<global::Together.RerankRequestModel?, string>? Type284 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.RerankRequestModel?, string>? Type285 { get; set; }
+        public global::Together.RerankRequestModel? Type285 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankRequestModel? Type286 { get; set; }
+        public global::Together.RerankResponse? Type286 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponse? Type287 { get; set; }
+        public global::Together.RerankResponseObject? Type287 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponseObject? Type288 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.RerankResponseResult>? Type288 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.RerankResponseResult>? Type289 { get; set; }
+        public global::Together.RerankResponseResult? Type289 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponseResult? Type290 { get; set; }
+        public global::Together.RerankResponseResultDocument? Type290 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponseResultDocument? Type291 { get; set; }
+        public global::Together.Response? Type291 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Response? Type292 { get; set; }
+        public global::Together.SessionListResponse? Type292 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponse? Type293 { get; set; }
+        public global::Together.SessionListResponseVariant1? Type293 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant1? Type294 { get; set; }
+        public global::Together.SessionListResponseVariant2? Type294 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant2? Type295 { get; set; }
+        public global::Together.SessionListResponseVariant2Data? Type295 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant2Data? Type296 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.SessionListResponseVariant2DataSession>? Type296 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.SessionListResponseVariant2DataSession>? Type297 { get; set; }
+        public global::Together.SessionListResponseVariant2DataSession? Type297 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant2DataSession? Type298 { get; set; }
+        public global::Together.StreamOutput? Type298 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.StreamOutput? Type299 { get; set; }
+        public global::Together.StreamOutputType? Type299 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.StreamOutputType? Type300 { get; set; }
+        public global::Together.UpdateEndpointRequest? Type300 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.UpdateEndpointRequest? Type301 { get; set; }
+        public global::Together.UpdateEndpointRequestState? Type301 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.UpdateEndpointRequestState? Type302 { get; set; }
+        public global::Together.Request? Type302 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Request? Type303 { get; set; }
+        public global::Together.Request2? Type303 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Request2? Type304 { get; set; }
+        public global::Together.OneOf<int?, global::Together.RequestBatchSize?>? Type304 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<int?, global::Together.RequestBatchSize?>? Type305 { get; set; }
+        public global::Together.RequestBatchSize? Type305 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestBatchSize? Type306 { get; set; }
+        public global::Together.OneOf<bool?, global::Together.RequestTrainOnInputs?>? Type306 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<bool?, global::Together.RequestTrainOnInputs?>? Type307 { get; set; }
+        public global::Together.RequestTrainOnInputs? Type307 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestTrainOnInputs? Type308 { get; set; }
+        public global::Together.Request3? Type308 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Request3? Type309 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.RequestImageLora>? Type309 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.RequestImageLora>? Type310 { get; set; }
+        public global::Together.RequestImageLora? Type310 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestImageLora? Type311 { get; set; }
+        public global::Together.AnyOf<global::Together.RequestModel?, string>? Type311 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.RequestModel?, string>? Type312 { get; set; }
+        public global::Together.RequestModel? Type312 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestModel? Type313 { get; set; }
+        public global::Together.RequestOutputFormat? Type313 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestOutputFormat? Type314 { get; set; }
+        public global::Together.RequestResponseFormat? Type314 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestResponseFormat? Type315 { get; set; }
+        public global::Together.ListEndpointsType? Type315 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointsType? Type316 { get; set; }
+        public global::Together.Checkpoint? Type316 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Checkpoint? Type317 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.BatchJob>? Type317 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.BatchJob>? Type318 { get; set; }
+        public global::Together.ListEndpointsResponse? Type318 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointsResponse? Type319 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ListEndpoint>? Type319 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ListEndpoint>? Type320 { get; set; }
+        public global::Together.ListEndpointsResponseObject? Type320 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointsResponseObject? Type321 { get; set; }
+        public global::Together.ListHardwareResponse? Type321 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListHardwareResponse? Type322 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.HardwareWithStatus>? Type322 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.HardwareWithStatus>? Type323 { get; set; }
-        /// <summary>
-        /// 
-        /// </summary>
-        public global::Together.ListHardwareResponseObject? Type324 { get; set; }
+        public global::Together.ListHardwareResponseObject? Type323 { get; set; }
     }
 }

--- a/src/libs/Together/Generated/Together.Models.AudioTranscriptionSegment.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioTranscriptionSegment.g.cs
@@ -45,13 +45,6 @@ namespace Together
         public required string Text { get; set; }
 
         /// <summary>
-        /// Array of token IDs for the segment
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("tokens")]
-        [global::System.Text.Json.Serialization.JsonRequired]
-        public required global::System.Collections.Generic.IList<int> Tokens { get; set; }
-
-        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -76,9 +69,6 @@ namespace Together
         /// The text content of the segment<br/>
         /// Example: Hello, world!
         /// </param>
-        /// <param name="tokens">
-        /// Array of token IDs for the segment
-        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -86,14 +76,12 @@ namespace Together
             float end,
             int id,
             float start,
-            string text,
-            global::System.Collections.Generic.IList<int> tokens)
+            string text)
         {
             this.End = end;
             this.Id = id;
             this.Start = start;
             this.Text = text ?? throw new global::System.ArgumentNullException(nameof(text));
-            this.Tokens = tokens ?? throw new global::System.ArgumentNullException(nameof(tokens));
         }
 
         /// <summary>

--- a/src/libs/Together/openapi.yaml
+++ b/src/libs/Together/openapi.yaml
@@ -1541,7 +1541,6 @@ components:
         - start
         - end
         - text
-        - tokens
       type: object
       properties:
         end:
@@ -1562,11 +1561,6 @@ components:
           type: string
           description: The text content of the segment
           example: 'Hello, world!'
-        tokens:
-          type: array
-          items:
-            type: integer
-          description: Array of token IDs for the segment
     AudioTranscriptionVerboseJsonResponse:
       required:
         - task


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the display of token ID arrays from audio transcription segment details in the API documentation. Other segment information remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->