### PR TITLE
feat:Add binary/URL audio schemas; make file a discriminated union

### DIFF
--- a/src/libs/Together/Generated/Together..JsonSerializerContext.g.cs
+++ b/src/libs/Together/Generated/Together..JsonSerializerContext.g.cs
@@ -13,6 +13,10 @@ namespace Together
         DefaultIgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
         Converters = new global::System.Type[] 
         { 
+            typeof(global::Together.JsonConverters.AudioFileBinaryTypeJsonConverter),
+            typeof(global::Together.JsonConverters.AudioFileBinaryTypeNullableJsonConverter),
+            typeof(global::Together.JsonConverters.AudioFileUrlTypeJsonConverter),
+            typeof(global::Together.JsonConverters.AudioFileUrlTypeNullableJsonConverter),
             typeof(global::Together.JsonConverters.AudioSpeechRequestLanguageJsonConverter),
             typeof(global::Together.JsonConverters.AudioSpeechRequestLanguageNullableJsonConverter),
             typeof(global::Together.JsonConverters.AudioSpeechRequestModelJsonConverter),
@@ -234,6 +238,7 @@ namespace Together
             typeof(global::Together.JsonConverters.ListHardwareResponseObjectJsonConverter),
             typeof(global::Together.JsonConverters.ListHardwareResponseObjectNullableJsonConverter),
             typeof(global::Together.JsonConverters.AudioSpeechStreamResponseJsonConverter),
+            typeof(global::Together.JsonConverters.FileJsonConverter),
             typeof(global::Together.JsonConverters.AudioTranscriptionResponseJsonConverter),
             typeof(global::Together.JsonConverters.AudioTranslationResponseJsonConverter),
             typeof(global::Together.JsonConverters.ChatCompletionMessageParamJsonConverter),
@@ -249,7 +254,6 @@ namespace Together
             typeof(global::Together.JsonConverters.SessionListResponseJsonConverter),
             typeof(global::Together.JsonConverters.AnyOfJsonConverter<global::Together.AudioSpeechRequestModel?, string>),
             typeof(global::Together.JsonConverters.AnyOfJsonConverter<global::Together.AudioSpeechRequestVoice?, string>),
-            typeof(global::Together.JsonConverters.OneOfJsonConverter<byte[], string>),
             typeof(global::Together.JsonConverters.OneOfJsonConverter<global::Together.AudioTranscriptionRequestTimestampGranularities?, global::System.Collections.Generic.IList<global::Together.AudioTranscriptionRequestTimestampGranularitie>>),
             typeof(global::Together.JsonConverters.OneOfJsonConverter<byte[], string>),
             typeof(global::Together.JsonConverters.OneOfJsonConverter<global::Together.AudioTranslationRequestTimestampGranularities?, global::System.Collections.Generic.IList<global::Together.AudioTranslationRequestTimestampGranularitie>>),

--- a/src/libs/Together/Generated/Together.AudioClient.AudioTranscriptions.g.cs
+++ b/src/libs/Together/Generated/Together.AudioClient.AudioTranscriptions.g.cs
@@ -347,7 +347,7 @@ namespace Together
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Together.AudioTranscriptionResponse> AudioTranscriptionsAsync(
-            global::Together.OneOf<byte[], string> file,
+            global::Together.File file,
             string? language = default,
             global::Together.AudioTranscriptionRequestModel? model = default,
             string? prompt = default,

--- a/src/libs/Together/Generated/Together.IAudioClient.AudioTranscriptions.g.cs
+++ b/src/libs/Together/Generated/Together.IAudioClient.AudioTranscriptions.g.cs
@@ -50,7 +50,7 @@ namespace Together
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Threading.Tasks.Task<global::Together.AudioTranscriptionResponse> AudioTranscriptionsAsync(
-            global::Together.OneOf<byte[], string> file,
+            global::Together.File file,
             string? language = default,
             global::Together.AudioTranscriptionRequestModel? model = default,
             string? prompt = default,

--- a/src/libs/Together/Generated/Together.JsonConverters.AudioFileBinaryType.g.cs
+++ b/src/libs/Together/Generated/Together.JsonConverters.AudioFileBinaryType.g.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+namespace Together.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class AudioFileBinaryTypeJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Together.AudioFileBinaryType>
+    {
+        /// <inheritdoc />
+        public override global::Together.AudioFileBinaryType Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Together.AudioFileBinaryTypeExtensions.ToEnum(stringValue) ?? default;
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Together.AudioFileBinaryType)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Together.AudioFileBinaryType);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Together.AudioFileBinaryType value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            writer.WriteStringValue(global::Together.AudioFileBinaryTypeExtensions.ToValueString(value));
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.JsonConverters.AudioFileBinaryTypeNullable.g.cs
+++ b/src/libs/Together/Generated/Together.JsonConverters.AudioFileBinaryTypeNullable.g.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace Together.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class AudioFileBinaryTypeNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Together.AudioFileBinaryType?>
+    {
+        /// <inheritdoc />
+        public override global::Together.AudioFileBinaryType? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Together.AudioFileBinaryTypeExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Together.AudioFileBinaryType)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Together.AudioFileBinaryType?);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Together.AudioFileBinaryType? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Together.AudioFileBinaryTypeExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.JsonConverters.AudioFileUrlType.g.cs
+++ b/src/libs/Together/Generated/Together.JsonConverters.AudioFileUrlType.g.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+namespace Together.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class AudioFileUrlTypeJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Together.AudioFileUrlType>
+    {
+        /// <inheritdoc />
+        public override global::Together.AudioFileUrlType Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Together.AudioFileUrlTypeExtensions.ToEnum(stringValue) ?? default;
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Together.AudioFileUrlType)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Together.AudioFileUrlType);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Together.AudioFileUrlType value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            writer.WriteStringValue(global::Together.AudioFileUrlTypeExtensions.ToValueString(value));
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.JsonConverters.AudioFileUrlTypeNullable.g.cs
+++ b/src/libs/Together/Generated/Together.JsonConverters.AudioFileUrlTypeNullable.g.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace Together.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class AudioFileUrlTypeNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Together.AudioFileUrlType?>
+    {
+        /// <inheritdoc />
+        public override global::Together.AudioFileUrlType? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Together.AudioFileUrlTypeExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Together.AudioFileUrlType)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Together.AudioFileUrlType?);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Together.AudioFileUrlType? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Together.AudioFileUrlTypeExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.JsonConverters.File.g.cs
+++ b/src/libs/Together/Generated/Together.JsonConverters.File.g.cs
@@ -1,0 +1,87 @@
+#nullable enable
+#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace Together.JsonConverters
+{
+    /// <inheritdoc />
+    public class FileJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Together.File>
+    {
+        /// <inheritdoc />
+        public override global::Together.File Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            options = options ?? throw new global::System.ArgumentNullException(nameof(options));
+            var typeInfoResolver = options.TypeInfoResolver ?? throw new global::System.InvalidOperationException("TypeInfoResolver is not set.");
+
+            var
+            readerCopy = reader;
+            global::Together.AudioFileBinary? audioBinary = default;
+            try
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Together.AudioFileBinary), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Together.AudioFileBinary> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Together.AudioFileBinary).Name}");
+                audioBinary = global::System.Text.Json.JsonSerializer.Deserialize(ref readerCopy, typeInfo);
+            }
+            catch (global::System.Text.Json.JsonException)
+            {
+            }
+
+            readerCopy = reader;
+            global::Together.AudioFileUrl? audioUrl = default;
+            try
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Together.AudioFileUrl), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Together.AudioFileUrl> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Together.AudioFileUrl).Name}");
+                audioUrl = global::System.Text.Json.JsonSerializer.Deserialize(ref readerCopy, typeInfo);
+            }
+            catch (global::System.Text.Json.JsonException)
+            {
+            }
+
+            var result = new global::Together.File(
+                audioBinary,
+                audioUrl
+                );
+
+            if (audioBinary != null)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Together.AudioFileBinary), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Together.AudioFileBinary> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Together.AudioFileBinary).Name}");
+                _ = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
+            }
+            else if (audioUrl != null)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Together.AudioFileUrl), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Together.AudioFileUrl> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Together.AudioFileUrl).Name}");
+                _ = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Together.File value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            options = options ?? throw new global::System.ArgumentNullException(nameof(options));
+            var typeInfoResolver = options.TypeInfoResolver ?? throw new global::System.InvalidOperationException("TypeInfoResolver is not set.");
+
+            if (value.IsAudioBinary)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Together.AudioFileBinary), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Together.AudioFileBinary?> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Together.AudioFileBinary).Name}");
+                global::System.Text.Json.JsonSerializer.Serialize(writer, value.AudioBinary, typeInfo);
+            }
+            else if (value.IsAudioUrl)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Together.AudioFileUrl), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Together.AudioFileUrl?> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Together.AudioFileUrl).Name}");
+                global::System.Text.Json.JsonSerializer.Serialize(writer, value.AudioUrl, typeInfo);
+            }
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.JsonSerializerContextTypes.g.cs
+++ b/src/libs/Together/Generated/Together.JsonSerializerContextTypes.g.cs
@@ -26,1458 +26,1482 @@ namespace Together
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechRequest? Type0 { get; set; }
+        public global::Together.AudioFileBinary? Type0 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public string? Type1 { get; set; }
+        public byte[]? Type1 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechRequestLanguage? Type2 { get; set; }
+        public global::Together.AudioFileBinaryType? Type2 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.AudioSpeechRequestModel?, string>? Type3 { get; set; }
+        public global::Together.AudioFileUrl? Type3 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechRequestModel? Type4 { get; set; }
+        public global::Together.AudioFileUrlType? Type4 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechRequestResponseEncoding? Type5 { get; set; }
+        public string? Type5 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechRequestResponseFormat? Type6 { get; set; }
+        public global::Together.AudioSpeechRequest? Type6 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public double? Type7 { get; set; }
+        public global::Together.AudioSpeechRequestLanguage? Type7 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public bool? Type8 { get; set; }
+        public global::Together.AnyOf<global::Together.AudioSpeechRequestModel?, string>? Type8 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.AudioSpeechRequestVoice?, string>? Type9 { get; set; }
+        public global::Together.AudioSpeechRequestModel? Type9 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechRequestVoice? Type10 { get; set; }
+        public global::Together.AudioSpeechRequestResponseEncoding? Type10 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechStreamChunk? Type11 { get; set; }
+        public global::Together.AudioSpeechRequestResponseFormat? Type11 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechStreamChunkObject? Type12 { get; set; }
+        public double? Type12 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechStreamEvent? Type13 { get; set; }
+        public bool? Type13 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioSpeechStreamResponse? Type14 { get; set; }
+        public global::Together.AnyOf<global::Together.AudioSpeechRequestVoice?, string>? Type14 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.StreamSentinel? Type15 { get; set; }
+        public global::Together.AudioSpeechRequestVoice? Type15 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.StreamSentinelData? Type16 { get; set; }
+        public global::Together.AudioSpeechStreamChunk? Type16 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionJsonResponse? Type17 { get; set; }
+        public global::Together.AudioSpeechStreamChunkObject? Type17 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionRequest? Type18 { get; set; }
+        public global::Together.AudioSpeechStreamEvent? Type18 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<byte[], string>? Type19 { get; set; }
+        public global::Together.AudioSpeechStreamResponse? Type19 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public byte[]? Type20 { get; set; }
+        public global::Together.StreamSentinel? Type20 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionRequestModel? Type21 { get; set; }
+        public global::Together.StreamSentinelData? Type21 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionRequestResponseFormat? Type22 { get; set; }
+        public global::Together.AudioTranscriptionJsonResponse? Type22 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public float? Type23 { get; set; }
+        public global::Together.AudioTranscriptionRequest? Type23 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.AudioTranscriptionRequestTimestampGranularities?, global::System.Collections.Generic.IList<global::Together.AudioTranscriptionRequestTimestampGranularitie>>? Type24 { get; set; }
+        public global::Together.File? Type24 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionRequestTimestampGranularities? Type25 { get; set; }
+        public global::Together.AudioTranscriptionRequestFileDiscriminator? Type25 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionRequestTimestampGranularitie>? Type26 { get; set; }
+        public global::Together.AudioTranscriptionRequestModel? Type26 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionRequestTimestampGranularitie? Type27 { get; set; }
+        public global::Together.AudioTranscriptionRequestResponseFormat? Type27 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionResponse? Type28 { get; set; }
+        public float? Type28 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionVerboseJsonResponse? Type29 { get; set; }
+        public global::Together.OneOf<global::Together.AudioTranscriptionRequestTimestampGranularities?, global::System.Collections.Generic.IList<global::Together.AudioTranscriptionRequestTimestampGranularitie>>? Type29 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionSegment>? Type30 { get; set; }
+        public global::Together.AudioTranscriptionRequestTimestampGranularities? Type30 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionSegment? Type31 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionRequestTimestampGranularitie>? Type31 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public int? Type32 { get; set; }
+        public global::Together.AudioTranscriptionRequestTimestampGranularitie? Type32 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionVerboseJsonResponseTask? Type33 { get; set; }
+        public global::Together.AudioTranscriptionResponse? Type33 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionWord>? Type34 { get; set; }
+        public global::Together.AudioTranscriptionVerboseJsonResponse? Type34 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranscriptionWord? Type35 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionSegment>? Type35 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationJsonResponse? Type36 { get; set; }
+        public global::Together.AudioTranscriptionSegment? Type36 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequest? Type37 { get; set; }
+        public int? Type37 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequestModel? Type38 { get; set; }
+        public global::Together.AudioTranscriptionVerboseJsonResponseTask? Type38 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequestResponseFormat? Type39 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.AudioTranscriptionWord>? Type39 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.AudioTranslationRequestTimestampGranularities?, global::System.Collections.Generic.IList<global::Together.AudioTranslationRequestTimestampGranularitie>>? Type40 { get; set; }
+        public global::Together.AudioTranscriptionWord? Type40 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequestTimestampGranularities? Type41 { get; set; }
+        public global::Together.AudioTranslationJsonResponse? Type41 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.AudioTranslationRequestTimestampGranularitie>? Type42 { get; set; }
+        public global::Together.AudioTranslationRequest? Type42 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationRequestTimestampGranularitie? Type43 { get; set; }
+        public global::Together.OneOf<byte[], string>? Type43 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationResponse? Type44 { get; set; }
+        public global::Together.AudioTranslationRequestModel? Type44 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationVerboseJsonResponse? Type45 { get; set; }
+        public global::Together.AudioTranslationRequestResponseFormat? Type45 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AudioTranslationVerboseJsonResponseTask? Type46 { get; set; }
+        public global::Together.OneOf<global::Together.AudioTranslationRequestTimestampGranularities?, global::System.Collections.Generic.IList<global::Together.AudioTranslationRequestTimestampGranularitie>>? Type46 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Autoscaling? Type47 { get; set; }
+        public global::Together.AudioTranslationRequestTimestampGranularities? Type47 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchErrorResponse? Type48 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.AudioTranslationRequestTimestampGranularitie>? Type48 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchJob? Type49 { get; set; }
+        public global::Together.AudioTranslationRequestTimestampGranularitie? Type49 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.DateTime? Type50 { get; set; }
+        public global::Together.AudioTranslationResponse? Type50 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public long? Type51 { get; set; }
+        public global::Together.AudioTranslationVerboseJsonResponse? Type51 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Guid? Type52 { get; set; }
+        public global::Together.AudioTranslationVerboseJsonResponseTask? Type52 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchJobStatus? Type53 { get; set; }
+        public global::Together.Autoscaling? Type53 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.BatchJobWithWarning? Type54 { get; set; }
+        public global::Together.BatchErrorResponse? Type54 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionAssistantMessageParam? Type55 { get; set; }
+        public global::Together.BatchJob? Type55 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionAssistantMessageParamFunctionCall? Type56 { get; set; }
+        public global::System.DateTime? Type56 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionAssistantMessageParamRole? Type57 { get; set; }
+        public long? Type57 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ToolChoice2>? Type58 { get; set; }
+        public global::System.Guid? Type58 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolChoice2? Type59 { get; set; }
+        public global::Together.BatchJobStatus? Type59 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolChoiceFunction? Type60 { get; set; }
+        public global::Together.BatchJobWithWarning? Type60 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolChoiceType? Type61 { get; set; }
+        public global::Together.ChatCompletionAssistantMessageParam? Type61 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoice? Type62 { get; set; }
+        public global::Together.ChatCompletionAssistantMessageParamFunctionCall? Type62 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoiceDelta? Type63 { get; set; }
+        public global::Together.ChatCompletionAssistantMessageParamRole? Type63 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoiceDeltaFunctionCall? Type64 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ToolChoice2>? Type64 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoiceDeltaRole? Type65 { get; set; }
+        public global::Together.ToolChoice2? Type65 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinishReason? Type66 { get; set; }
+        public global::Together.ToolChoiceFunction? Type66 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LogprobsPart? Type67 { get; set; }
+        public global::Together.ToolChoiceType? Type67 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<double>? Type68 { get; set; }
+        public global::Together.ChatCompletionChoice? Type68 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<string>? Type69 { get; set; }
+        public global::Together.ChatCompletionChoiceDelta? Type69 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChoicesDataItem>? Type70 { get; set; }
+        public global::Together.ChatCompletionChoiceDeltaFunctionCall? Type70 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChoicesDataItem? Type71 { get; set; }
+        public global::Together.ChatCompletionChoiceDeltaRole? Type71 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessage? Type72 { get; set; }
+        public global::Together.FinishReason? Type72 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessageFunctionCall? Type73 { get; set; }
+        public global::Together.LogprobsPart? Type73 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessageRole? Type74 { get; set; }
+        public global::System.Collections.Generic.IList<double>? Type74 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunk? Type75 { get; set; }
+        public global::System.Collections.Generic.IList<string>? Type75 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChunkChoice>? Type76 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChoicesDataItem>? Type76 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoice? Type77 { get; set; }
+        public global::Together.ChatCompletionChoicesDataItem? Type77 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoiceDelta? Type78 { get; set; }
+        public global::Together.ChatCompletionMessage? Type78 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoiceDeltaFunctionCall? Type79 { get; set; }
+        public global::Together.ChatCompletionMessageFunctionCall? Type79 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkChoiceDeltaRole? Type80 { get; set; }
+        public global::Together.ChatCompletionMessageRole? Type80 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionChunkObject? Type81 { get; set; }
+        public global::Together.ChatCompletionChunk? Type81 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.UsageData? Type82 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ChatCompletionChunkChoice>? Type82 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.InferenceWarning>? Type83 { get; set; }
+        public global::Together.ChatCompletionChunkChoice? Type83 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InferenceWarning? Type84 { get; set; }
+        public global::Together.ChatCompletionChunkChoiceDelta? Type84 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionEvent? Type85 { get; set; }
+        public global::Together.ChatCompletionChunkChoiceDeltaFunctionCall? Type85 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionFunctionMessageParam? Type86 { get; set; }
+        public global::Together.ChatCompletionChunkChoiceDeltaRole? Type86 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionFunctionMessageParamRole? Type87 { get; set; }
+        public global::Together.ChatCompletionChunkObject? Type87 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionMessageParam? Type88 { get; set; }
+        public global::Together.UsageData? Type88 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionSystemMessageParam? Type89 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.InferenceWarning>? Type89 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionSystemMessageParamRole? Type90 { get; set; }
+        public global::Together.InferenceWarning? Type90 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageParam? Type91 { get; set; }
+        public global::Together.ChatCompletionEvent? Type91 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContent? Type92 { get; set; }
+        public global::Together.ChatCompletionFunctionMessageParam? Type92 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>>? Type93 { get; set; }
+        public global::Together.ChatCompletionFunctionMessageParamRole? Type93 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>? Type94 { get; set; }
+        public global::Together.ChatCompletionMessageParam? Type94 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1? Type95 { get; set; }
+        public global::Together.ChatCompletionSystemMessageParam? Type95 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1Type? Type96 { get; set; }
+        public global::Together.ChatCompletionSystemMessageParamRole? Type96 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2? Type97 { get; set; }
+        public global::Together.ChatCompletionUserMessageParam? Type97 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2ImageUrl? Type98 { get; set; }
+        public global::Together.ChatCompletionUserMessageContent? Type98 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2Type? Type99 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>>? Type99 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3? Type100 { get; set; }
+        public global::Together.OneOf<global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4, global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5>? Type100 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3Type? Type101 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1? Type101 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3VideoUrl? Type102 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant1Type? Type102 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4? Type103 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2? Type103 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4AudioUrl? Type104 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2ImageUrl? Type104 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4Type? Type105 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant2Type? Type105 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5? Type106 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3? Type106 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudio? Type107 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3Type? Type107 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudioFormat? Type108 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant3VideoUrl? Type108 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5Type? Type109 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4? Type109 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionUserMessageParamRole? Type110 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4AudioUrl? Type110 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolMessageParam? Type111 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant4Type? Type111 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolMessageParamRole? Type112 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5? Type112 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequest? Type113 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudio? Type113 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestContextLengthExceededBehavior? Type114 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5InputAudioFormat? Type114 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.ChatCompletionRequestFunctionCallEnum?, global::Together.ChatCompletionRequestFunctionCallEnum2>? Type115 { get; set; }
+        public global::Together.ChatCompletionUserMessageContentMultimodalItemVariant5Type? Type115 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestFunctionCallEnum? Type116 { get; set; }
+        public global::Together.ChatCompletionUserMessageParamRole? Type116 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestFunctionCallEnum2? Type117 { get; set; }
+        public global::Together.ChatCompletionToolMessageParam? Type117 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.Dictionary<string, float>? Type118 { get; set; }
+        public global::Together.ChatCompletionToolMessageParamRole? Type118 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ChatCompletionMessageParam>? Type119 { get; set; }
+        public global::Together.ChatCompletionRequest? Type119 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.ChatCompletionRequestModel?, string>? Type120 { get; set; }
+        public global::Together.ChatCompletionRequestContextLengthExceededBehavior? Type120 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestModel? Type121 { get; set; }
+        public global::Together.OneOf<global::Together.ChatCompletionRequestFunctionCallEnum?, global::Together.ChatCompletionRequestFunctionCallEnum2>? Type121 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestReasoningEffort? Type122 { get; set; }
+        public global::Together.ChatCompletionRequestFunctionCallEnum? Type122 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionRequestResponseFormat? Type123 { get; set; }
+        public global::Together.ChatCompletionRequestFunctionCallEnum2? Type123 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public object? Type124 { get; set; }
+        public global::System.Collections.Generic.Dictionary<string, float>? Type124 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<string, global::Together.ToolChoice2>? Type125 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ChatCompletionMessageParam>? Type125 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ToolsPart>? Type126 { get; set; }
+        public global::Together.AnyOf<global::Together.ChatCompletionRequestModel?, string>? Type126 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolsPart? Type127 { get; set; }
+        public global::Together.ChatCompletionRequestModel? Type127 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ToolsPartFunction? Type128 { get; set; }
+        public global::Together.ChatCompletionRequestReasoningEffort? Type128 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionResponse? Type129 { get; set; }
+        public global::Together.ChatCompletionRequestResponseFormat? Type129 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionResponseObject? Type130 { get; set; }
+        public object? Type130 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionStream? Type131 { get; set; }
+        public global::Together.OneOf<string, global::Together.ToolChoice2>? Type131 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToken? Type132 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ToolsPart>? Type132 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionTool? Type133 { get; set; }
+        public global::Together.ToolsPart? Type133 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolFunction? Type134 { get; set; }
+        public global::Together.ToolsPartFunction? Type134 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ChatCompletionToolType? Type135 { get; set; }
+        public global::Together.ChatCompletionResponse? Type135 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoice? Type136 { get; set; }
+        public global::Together.ChatCompletionResponseObject? Type136 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoiceDelta? Type137 { get; set; }
+        public global::Together.ChatCompletionStream? Type137 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoiceDeltaFunctionCall? Type138 { get; set; }
+        public global::Together.ChatCompletionToken? Type138 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoiceDeltaRole? Type139 { get; set; }
+        public global::Together.ChatCompletionTool? Type139 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.CompletionChoicesDataItem>? Type140 { get; set; }
+        public global::Together.ChatCompletionToolFunction? Type140 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChoicesDataItem? Type141 { get; set; }
+        public global::Together.ChatCompletionToolType? Type141 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChunk? Type142 { get; set; }
+        public global::Together.CompletionChoice? Type142 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.CompletionChoice>? Type143 { get; set; }
+        public global::Together.CompletionChoiceDelta? Type143 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionChunkObject? Type144 { get; set; }
+        public global::Together.CompletionChoiceDeltaFunctionCall? Type144 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionToken? Type145 { get; set; }
+        public global::Together.CompletionChoiceDeltaRole? Type145 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionEvent? Type146 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.CompletionChoicesDataItem>? Type146 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionRequest? Type147 { get; set; }
+        public global::Together.CompletionChoicesDataItem? Type147 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.CompletionRequestModel?, string>? Type148 { get; set; }
+        public global::Together.CompletionChunk? Type148 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionRequestModel? Type149 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.CompletionChoice>? Type149 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.CompletionRequestSafetyModel?, string>? Type150 { get; set; }
+        public global::Together.CompletionChunkObject? Type150 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionRequestSafetyModel? Type151 { get; set; }
+        public global::Together.CompletionToken? Type151 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionResponse? Type152 { get; set; }
+        public global::Together.CompletionEvent? Type152 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionResponseObject? Type153 { get; set; }
+        public global::Together.CompletionRequest? Type153 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.PromptPartItem>? Type154 { get; set; }
+        public global::Together.AnyOf<global::Together.CompletionRequestModel?, string>? Type154 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.PromptPartItem? Type155 { get; set; }
+        public global::Together.CompletionRequestModel? Type155 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CompletionStream? Type156 { get; set; }
+        public global::Together.AnyOf<global::Together.CompletionRequestSafetyModel?, string>? Type156 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CosineLRSchedulerArgs? Type157 { get; set; }
+        public global::Together.CompletionRequestSafetyModel? Type157 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CreateBatchRequest? Type158 { get; set; }
+        public global::Together.CompletionResponse? Type158 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CreateEndpointRequest? Type159 { get; set; }
+        public global::Together.CompletionResponseObject? Type159 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.CreateEndpointRequestState? Type160 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.PromptPartItem>? Type160 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpoint? Type161 { get; set; }
+        public global::Together.PromptPartItem? Type161 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpointObject? Type162 { get; set; }
+        public global::Together.CompletionStream? Type162 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpointState? Type163 { get; set; }
+        public global::Together.CosineLRSchedulerArgs? Type163 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DedicatedEndpointType? Type164 { get; set; }
+        public global::Together.CreateBatchRequest? Type164 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DisplayorExecuteOutput? Type165 { get; set; }
+        public global::Together.CreateEndpointRequest? Type165 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DisplayorExecuteOutputData? Type166 { get; set; }
+        public global::Together.CreateEndpointRequestState? Type166 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DisplayorExecuteOutputType? Type167 { get; set; }
+        public global::Together.DedicatedEndpoint? Type167 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsRequest? Type168 { get; set; }
+        public global::Together.DedicatedEndpointObject? Type168 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<string, global::System.Collections.Generic.IList<string>>? Type169 { get; set; }
+        public global::Together.DedicatedEndpointState? Type169 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.EmbeddingsRequestModel?, string>? Type170 { get; set; }
+        public global::Together.DedicatedEndpointType? Type170 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsRequestModel? Type171 { get; set; }
+        public global::Together.DisplayorExecuteOutput? Type171 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponse? Type172 { get; set; }
+        public global::Together.DisplayorExecuteOutputData? Type172 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.EmbeddingsResponseDataItem>? Type173 { get; set; }
+        public global::Together.DisplayorExecuteOutputType? Type173 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponseDataItem? Type174 { get; set; }
+        public global::Together.EmbeddingsRequest? Type174 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponseDataItemObject? Type175 { get; set; }
+        public global::Together.OneOf<string, global::System.Collections.Generic.IList<string>>? Type175 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EmbeddingsResponseObject? Type176 { get; set; }
+        public global::Together.AnyOf<global::Together.EmbeddingsRequestModel?, string>? Type176 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EndpointPricing? Type177 { get; set; }
+        public global::Together.EmbeddingsRequestModel? Type177 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Error? Type178 { get; set; }
+        public global::Together.EmbeddingsResponse? Type178 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorData? Type179 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.EmbeddingsResponseDataItem>? Type179 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorDataError? Type180 { get; set; }
+        public global::Together.EmbeddingsResponseDataItem? Type180 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorOutput? Type181 { get; set; }
+        public global::Together.EmbeddingsResponseDataItemObject? Type181 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ErrorOutputType? Type182 { get; set; }
+        public global::Together.EmbeddingsResponseObject? Type182 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationClassifyParameters? Type183 { get; set; }
+        public global::Together.EndpointPricing? Type183 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationJudgeModelConfig? Type184 { get; set; }
+        public global::Together.Error? Type184 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationModelOrString? Type185 { get; set; }
+        public global::Together.ErrorData? Type185 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationModelRequest? Type186 { get; set; }
+        public global::Together.ErrorDataError? Type186 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationClassifyResults? Type187 { get; set; }
+        public global::Together.ErrorOutput? Type187 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationCompareParameters? Type188 { get; set; }
+        public global::Together.ErrorOutputType? Type188 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationCompareResults? Type189 { get; set; }
+        public global::Together.EvaluationClassifyParameters? Type189 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationJob? Type190 { get; set; }
+        public global::Together.EvaluationJudgeModelConfig? Type190 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.EvaluationClassifyResults, global::Together.EvaluationScoreResults, global::Together.EvaluationCompareResults, global::Together.EvaluationJobResults>? Type191 { get; set; }
+        public global::Together.EvaluationModelOrString? Type191 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationScoreResults? Type192 { get; set; }
+        public global::Together.EvaluationModelRequest? Type192 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationJobResults? Type193 { get; set; }
+        public global::Together.EvaluationClassifyResults? Type193 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationJobStatus? Type194 { get; set; }
+        public global::Together.EvaluationCompareParameters? Type194 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.EvaluationJobStatusUpdate>? Type195 { get; set; }
+        public global::Together.EvaluationCompareResults? Type195 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationJobStatusUpdate? Type196 { get; set; }
+        public global::Together.EvaluationJob? Type196 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationJobType? Type197 { get; set; }
+        public global::Together.OneOf<global::Together.EvaluationClassifyResults, global::Together.EvaluationScoreResults, global::Together.EvaluationCompareResults, global::Together.EvaluationJobResults>? Type197 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationResponse? Type198 { get; set; }
+        public global::Together.EvaluationScoreResults? Type198 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationResponseStatus? Type199 { get; set; }
+        public global::Together.EvaluationJobResults? Type199 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationScoreParameters? Type200 { get; set; }
+        public global::Together.EvaluationJobStatus? Type200 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationTypedRequest? Type201 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.EvaluationJobStatusUpdate>? Type201 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.EvaluationClassifyParameters, global::Together.EvaluationScoreParameters, global::Together.EvaluationCompareParameters>? Type202 { get; set; }
+        public global::Together.EvaluationJobStatusUpdate? Type202 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationTypedRequestType? Type203 { get; set; }
+        public global::Together.EvaluationJobType? Type203 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequest? Type204 { get; set; }
+        public global::Together.EvaluationResponse? Type204 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ExecuteRequestFile>? Type205 { get; set; }
+        public global::Together.EvaluationResponseStatus? Type205 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequestFile? Type206 { get; set; }
+        public global::Together.EvaluationScoreParameters? Type206 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequestFileEncoding? Type207 { get; set; }
+        public global::Together.EvaluationTypedRequest? Type207 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteRequestLanguage? Type208 { get; set; }
+        public global::Together.OneOf<global::Together.EvaluationClassifyParameters, global::Together.EvaluationScoreParameters, global::Together.EvaluationCompareParameters>? Type208 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponse? Type209 { get; set; }
+        public global::Together.EvaluationTypedRequestType? Type209 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1? Type210 { get; set; }
+        public global::Together.ExecuteRequest? Type210 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1Data? Type211 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ExecuteRequestFile>? Type211 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.OutputsItem>? Type212 { get; set; }
+        public global::Together.ExecuteRequestFile? Type212 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OutputsItem? Type213 { get; set; }
+        public global::Together.ExecuteRequestFileEncoding? Type213 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant1? Type214 { get; set; }
+        public global::Together.ExecuteRequestLanguage? Type214 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant1Type? Type215 { get; set; }
+        public global::Together.ExecuteResponse? Type215 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant2? Type216 { get; set; }
+        public global::Together.ExecuteResponseVariant1? Type216 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant2Type? Type217 { get; set; }
+        public global::Together.ExecuteResponseVariant1Data? Type217 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant3? Type218 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.OutputsItem>? Type218 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant3Data? Type219 { get; set; }
+        public global::Together.OutputsItem? Type219 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputVariant3Type? Type220 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant1? Type220 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataOutputDiscriminator? Type221 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant1Type? Type221 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant1DataStatus? Type222 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant2? Type222 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ExecuteResponseVariant2? Type223 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant2Type? Type223 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.OneOf<string, object>>? Type224 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant3? Type224 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<string, object>? Type225 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant3Data? Type225 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileDeleteResponse? Type226 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputVariant3Type? Type226 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileList? Type227 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataOutputDiscriminator? Type227 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FileResponse>? Type228 { get; set; }
+        public global::Together.ExecuteResponseVariant1DataStatus? Type228 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileResponse? Type229 { get; set; }
+        public global::Together.ExecuteResponseVariant2? Type229 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileType? Type230 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.OneOf<string, object>>? Type230 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FilePurpose? Type231 { get; set; }
+        public global::Together.OneOf<string, object>? Type231 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FileObject? Type232 { get; set; }
+        public global::Together.FileDeleteResponse? Type232 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FineTuneCheckpoint? Type233 { get; set; }
+        public global::Together.FileList? Type233 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FineTuneEvent? Type234 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FileResponse>? Type234 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneEventLevels? Type235 { get; set; }
+        public global::Together.FileResponse? Type235 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FineTuneEventObject? Type236 { get; set; }
+        public global::Together.FileType? Type236 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneEventType? Type237 { get; set; }
+        public global::Together.FilePurpose? Type237 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneDownloadResult? Type238 { get; set; }
+        public global::Together.FileObject? Type238 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneDownloadResultObject? Type239 { get; set; }
+        public global::Together.FineTuneCheckpoint? Type239 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneJobStatus? Type240 { get; set; }
+        public global::Together.FineTuneEvent? Type240 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneListCheckpoints? Type241 { get; set; }
+        public global::Together.FinetuneEventLevels? Type241 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FineTuneCheckpoint>? Type242 { get; set; }
+        public global::Together.FineTuneEventObject? Type242 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneListEvents? Type243 { get; set; }
+        public global::Together.FinetuneEventType? Type243 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FineTuneEvent>? Type244 { get; set; }
+        public global::Together.FinetuneDownloadResult? Type244 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponse? Type245 { get; set; }
+        public global::Together.FinetuneDownloadResultObject? Type245 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<int?, global::Together.FinetuneResponseBatchSize?>? Type246 { get; set; }
+        public global::Together.FinetuneJobStatus? Type246 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponseBatchSize? Type247 { get; set; }
+        public global::Together.FinetuneListCheckpoints? Type247 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LRScheduler? Type248 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FineTuneCheckpoint>? Type248 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.LinearLRSchedulerArgs, global::Together.CosineLRSchedulerArgs>? Type249 { get; set; }
+        public global::Together.FinetuneListEvents? Type249 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LinearLRSchedulerArgs? Type250 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FineTuneEvent>? Type250 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LRSchedulerLrSchedulerType? Type251 { get; set; }
+        public global::Together.FinetuneResponse? Type251 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<bool?, global::Together.FinetuneResponseTrainOnInputs?>? Type252 { get; set; }
+        public global::Together.OneOf<int?, global::Together.FinetuneResponseBatchSize?>? Type252 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponseTrainOnInputs? Type253 { get; set; }
+        public global::Together.FinetuneResponseBatchSize? Type253 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.TrainingMethodSFT, global::Together.TrainingMethodDPO>? Type254 { get; set; }
+        public global::Together.LRScheduler? Type254 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodSFT? Type255 { get; set; }
+        public global::Together.OneOf<global::Together.LinearLRSchedulerArgs, global::Together.CosineLRSchedulerArgs>? Type255 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodSFTMethod? Type256 { get; set; }
+        public global::Together.LinearLRSchedulerArgs? Type256 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<bool?, global::Together.TrainingMethodSFTTrainOnInputs?>? Type257 { get; set; }
+        public global::Together.LRSchedulerLrSchedulerType? Type257 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodSFTTrainOnInputs? Type258 { get; set; }
+        public global::Together.OneOf<bool?, global::Together.FinetuneResponseTrainOnInputs?>? Type258 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodDPO? Type259 { get; set; }
+        public global::Together.FinetuneResponseTrainOnInputs? Type259 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.TrainingMethodDPOMethod? Type260 { get; set; }
+        public global::Together.OneOf<global::Together.TrainingMethodSFT, global::Together.TrainingMethodDPO>? Type260 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.FullTrainingType, global::Together.LoRATrainingType>? Type261 { get; set; }
+        public global::Together.TrainingMethodSFT? Type261 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FullTrainingType? Type262 { get; set; }
+        public global::Together.TrainingMethodSFTMethod? Type262 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FullTrainingTypeType? Type263 { get; set; }
+        public global::Together.OneOf<bool?, global::Together.TrainingMethodSFTTrainOnInputs?>? Type263 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LoRATrainingType? Type264 { get; set; }
+        public global::Together.TrainingMethodSFTTrainOnInputs? Type264 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.LoRATrainingTypeType? Type265 { get; set; }
+        public global::Together.TrainingMethodDPO? Type265 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneResponseTruncated? Type266 { get; set; }
+        public global::Together.TrainingMethodDPOMethod? Type266 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.FinetuneTruncatedList? Type267 { get; set; }
+        public global::Together.OneOf<global::Together.FullTrainingType, global::Together.LoRATrainingType>? Type267 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.FinetuneResponseTruncated>? Type268 { get; set; }
+        public global::Together.FullTrainingType? Type268 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareAvailability? Type269 { get; set; }
+        public global::Together.FullTrainingTypeType? Type269 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareAvailabilityStatus? Type270 { get; set; }
+        public global::Together.LoRATrainingType? Type270 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareSpec? Type271 { get; set; }
+        public global::Together.LoRATrainingTypeType? Type271 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareWithStatus? Type272 { get; set; }
+        public global::Together.FinetuneResponseTruncated? Type272 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.HardwareWithStatusObject? Type273 { get; set; }
+        public global::Together.FinetuneTruncatedList? Type273 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponse? Type274 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.FinetuneResponseTruncated>? Type274 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.DataItem>? Type275 { get; set; }
+        public global::Together.HardwareAvailability? Type275 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.DataItem? Type276 { get; set; }
+        public global::Together.HardwareAvailabilityStatus? Type276 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataB64? Type277 { get; set; }
+        public global::Together.HardwareSpec? Type277 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataB64Type? Type278 { get; set; }
+        public global::Together.HardwareWithStatus? Type278 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataUrl? Type279 { get; set; }
+        public global::Together.HardwareWithStatusObject? Type279 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataUrlType? Type280 { get; set; }
+        public global::Together.ImageResponse? Type280 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseDataItemDiscriminator? Type281 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.DataItem>? Type281 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ImageResponseObject? Type282 { get; set; }
+        public global::Together.DataItem? Type282 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutput? Type283 { get; set; }
+        public global::Together.ImageResponseDataB64? Type283 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant1? Type284 { get; set; }
+        public global::Together.ImageResponseDataB64Type? Type284 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant1Type? Type285 { get; set; }
+        public global::Together.ImageResponseDataUrl? Type285 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant2? Type286 { get; set; }
+        public global::Together.ImageResponseDataUrlType? Type286 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant2Type? Type287 { get; set; }
+        public global::Together.ImageResponseDataItemDiscriminator? Type287 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant3? Type288 { get; set; }
+        public global::Together.ImageResponseObject? Type288 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant3Data? Type289 { get; set; }
+        public global::Together.InterpreterOutput? Type289 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputVariant3Type? Type290 { get; set; }
+        public global::Together.InterpreterOutputVariant1? Type290 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.InterpreterOutputDiscriminator? Type291 { get; set; }
+        public global::Together.InterpreterOutputVariant1Type? Type291 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponse? Type292 { get; set; }
+        public global::Together.InterpreterOutputVariant2? Type292 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponseArgs? Type293 { get; set; }
+        public global::Together.InterpreterOutputVariant2Type? Type293 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponseStatus? Type294 { get; set; }
+        public global::Together.InterpreterOutputVariant3? Type294 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponseStatusUpdate>? Type295 { get; set; }
+        public global::Together.InterpreterOutputVariant3Data? Type295 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobInfoSuccessResponseStatusUpdate? Type296 { get; set; }
+        public global::Together.InterpreterOutputVariant3Type? Type296 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.JobsInfoSuccessResponse? Type297 { get; set; }
+        public global::Together.InterpreterOutputDiscriminator? Type297 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponse>? Type298 { get; set; }
+        public global::Together.JobInfoSuccessResponse? Type298 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpoint? Type299 { get; set; }
+        public global::Together.JobInfoSuccessResponseArgs? Type299 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointObject? Type300 { get; set; }
+        public global::Together.JobInfoSuccessResponseStatus? Type300 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointState? Type301 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponseStatusUpdate>? Type301 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointType? Type302 { get; set; }
+        public global::Together.JobInfoSuccessResponseStatusUpdate? Type302 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelInfo? Type303 { get; set; }
+        public global::Together.JobsInfoSuccessResponse? Type303 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Pricing? Type304 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.JobInfoSuccessResponse>? Type304 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelInfoType? Type305 { get; set; }
+        public global::Together.ListEndpoint? Type305 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ModelInfo>? Type306 { get; set; }
+        public global::Together.ListEndpointObject? Type306 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadRequest? Type307 { get; set; }
+        public global::Together.ListEndpointState? Type307 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadRequestModelType? Type308 { get; set; }
+        public global::Together.ListEndpointType? Type308 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadSuccessResponse? Type309 { get; set; }
+        public global::Together.ModelInfo? Type309 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ModelUploadSuccessResponseData? Type310 { get; set; }
+        public global::Together.Pricing? Type310 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankRequest? Type311 { get; set; }
+        public global::Together.ModelInfoType? Type311 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::System.Collections.Generic.IList<object>, global::System.Collections.Generic.IList<string>>? Type312 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ModelInfo>? Type312 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<object>? Type313 { get; set; }
+        public global::Together.ModelUploadRequest? Type313 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.RerankRequestModel?, string>? Type314 { get; set; }
+        public global::Together.ModelUploadRequestModelType? Type314 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankRequestModel? Type315 { get; set; }
+        public global::Together.ModelUploadSuccessResponse? Type315 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponse? Type316 { get; set; }
+        public global::Together.ModelUploadSuccessResponseData? Type316 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponseObject? Type317 { get; set; }
+        public global::Together.RerankRequest? Type317 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.RerankResponseResult>? Type318 { get; set; }
+        public global::Together.OneOf<global::System.Collections.Generic.IList<object>, global::System.Collections.Generic.IList<string>>? Type318 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponseResult? Type319 { get; set; }
+        public global::System.Collections.Generic.IList<object>? Type319 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RerankResponseResultDocument? Type320 { get; set; }
+        public global::Together.AnyOf<global::Together.RerankRequestModel?, string>? Type320 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Response? Type321 { get; set; }
+        public global::Together.RerankRequestModel? Type321 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponse? Type322 { get; set; }
+        public global::Together.RerankResponse? Type322 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant1? Type323 { get; set; }
+        public global::Together.RerankResponseObject? Type323 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant2? Type324 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.RerankResponseResult>? Type324 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant2Data? Type325 { get; set; }
+        public global::Together.RerankResponseResult? Type325 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.SessionListResponseVariant2DataSession>? Type326 { get; set; }
+        public global::Together.RerankResponseResultDocument? Type326 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.SessionListResponseVariant2DataSession? Type327 { get; set; }
+        public global::Together.Response? Type327 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.StreamOutput? Type328 { get; set; }
+        public global::Together.SessionListResponse? Type328 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.StreamOutputType? Type329 { get; set; }
+        public global::Together.SessionListResponseVariant1? Type329 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.UpdateEndpointRequest? Type330 { get; set; }
+        public global::Together.SessionListResponseVariant2? Type330 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.UpdateEndpointRequestState? Type331 { get; set; }
+        public global::Together.SessionListResponseVariant2Data? Type331 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationUpdateRequest? Type332 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.SessionListResponseVariant2DataSession>? Type332 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationUpdateRequestStatus? Type333 { get; set; }
+        public global::Together.SessionListResponseVariant2DataSession? Type333 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Request? Type334 { get; set; }
+        public global::Together.StreamOutput? Type334 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Request2? Type335 { get; set; }
+        public global::Together.StreamOutputType? Type335 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<int?, global::Together.RequestBatchSize?>? Type336 { get; set; }
+        public global::Together.UpdateEndpointRequest? Type336 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestBatchSize? Type337 { get; set; }
+        public global::Together.UpdateEndpointRequestState? Type337 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<bool?, global::Together.RequestTrainOnInputs?>? Type338 { get; set; }
+        public global::Together.EvaluationUpdateRequest? Type338 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestTrainOnInputs? Type339 { get; set; }
+        public global::Together.EvaluationUpdateRequestStatus? Type339 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Request3? Type340 { get; set; }
+        public global::Together.Request? Type340 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.RequestImageLora>? Type341 { get; set; }
+        public global::Together.Request2? Type341 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestImageLora? Type342 { get; set; }
+        public global::Together.OneOf<int?, global::Together.RequestBatchSize?>? Type342 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.AnyOf<global::Together.RequestModel?, string>? Type343 { get; set; }
+        public global::Together.RequestBatchSize? Type343 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestModel? Type344 { get; set; }
+        public global::Together.OneOf<bool?, global::Together.RequestTrainOnInputs?>? Type344 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestOutputFormat? Type345 { get; set; }
+        public global::Together.RequestTrainOnInputs? Type345 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.RequestResponseFormat? Type346 { get; set; }
+        public global::Together.Request3? Type346 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointsType? Type347 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.RequestImageLora>? Type347 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationsListStatus? Type348 { get; set; }
+        public global::Together.RequestImageLora? Type348 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.Checkpoint? Type349 { get; set; }
+        public global::Together.AnyOf<global::Together.RequestModel?, string>? Type349 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.BatchJob>? Type350 { get; set; }
+        public global::Together.RequestModel? Type350 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointsResponse? Type351 { get; set; }
+        public global::Together.RequestOutputFormat? Type351 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.ListEndpoint>? Type352 { get; set; }
+        public global::Together.RequestResponseFormat? Type352 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListEndpointsResponseObject? Type353 { get; set; }
+        public global::Together.ListEndpointsType? Type353 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationStatusResponse? Type354 { get; set; }
+        public global::Together.EvaluationsListStatus? Type354 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.OneOf<global::Together.EvaluationClassifyResults, global::Together.EvaluationScoreResults, global::Together.EvaluationCompareResults, global::Together.EvaluationStatusResponseResults>? Type355 { get; set; }
+        public global::Together.Checkpoint? Type355 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationStatusResponseResults? Type356 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.BatchJob>? Type356 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationStatusResponseStatus? Type357 { get; set; }
+        public global::Together.ListEndpointsResponse? Type357 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationUpdateResponse? Type358 { get; set; }
+        public global::System.Collections.Generic.IList<global::Together.ListEndpoint>? Type358 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.EvaluationJob>? Type359 { get; set; }
+        public global::Together.ListEndpointsResponseObject? Type359 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.EvaluationsModelListResponse? Type360 { get; set; }
+        public global::Together.EvaluationStatusResponse? Type360 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListHardwareResponse? Type361 { get; set; }
+        public global::Together.OneOf<global::Together.EvaluationClassifyResults, global::Together.EvaluationScoreResults, global::Together.EvaluationCompareResults, global::Together.EvaluationStatusResponseResults>? Type361 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Together.HardwareWithStatus>? Type362 { get; set; }
+        public global::Together.EvaluationStatusResponseResults? Type362 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Together.ListHardwareResponseObject? Type363 { get; set; }
+        public global::Together.EvaluationStatusResponseStatus? Type363 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Together.EvaluationUpdateResponse? Type364 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::System.Collections.Generic.IList<global::Together.EvaluationJob>? Type365 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Together.EvaluationsModelListResponse? Type366 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Together.ListHardwareResponse? Type367 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::System.Collections.Generic.IList<global::Together.HardwareWithStatus>? Type368 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Together.ListHardwareResponseObject? Type369 { get; set; }
     }
 }

--- a/src/libs/Together/Generated/Together.Models.AudioFileBinary.Json.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioFileBinary.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Together
+{
+    public sealed partial class AudioFileBinary
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Together.AudioFileBinary? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Together.AudioFileBinary),
+                jsonSerializerContext) as global::Together.AudioFileBinary;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Together.AudioFileBinary? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Together.AudioFileBinary>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Together.AudioFileBinary?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Together.AudioFileBinary),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Together.AudioFileBinary;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Together.AudioFileBinary?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Together.AudioFileBinary?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.AudioFileBinary.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioFileBinary.g.cs
@@ -1,0 +1,68 @@
+
+#nullable enable
+
+namespace Together
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class AudioFileBinary
+    {
+        /// <summary>
+        /// Audio file to transcribe
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("data")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required byte[] Data { get; set; }
+
+        /// <summary>
+        /// Audio file to transcribe
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("dataname")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required string Dataname { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("type")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Together.JsonConverters.AudioFileBinaryTypeJsonConverter))]
+        public global::Together.AudioFileBinaryType Type { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioFileBinary" /> class.
+        /// </summary>
+        /// <param name="data">
+        /// Audio file to transcribe
+        /// </param>
+        /// <param name="dataname">
+        /// Audio file to transcribe
+        /// </param>
+        /// <param name="type"></param>
+#if NET7_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
+        public AudioFileBinary(
+            byte[] data,
+            string dataname,
+            global::Together.AudioFileBinaryType type)
+        {
+            this.Data = data ?? throw new global::System.ArgumentNullException(nameof(data));
+            this.Dataname = dataname ?? throw new global::System.ArgumentNullException(nameof(dataname));
+            this.Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioFileBinary" /> class.
+        /// </summary>
+        public AudioFileBinary()
+        {
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.AudioFileBinaryType.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioFileBinaryType.g.cs
@@ -1,0 +1,45 @@
+
+#nullable enable
+
+namespace Together
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum AudioFileBinaryType
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Binary,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class AudioFileBinaryTypeExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this AudioFileBinaryType value)
+        {
+            return value switch
+            {
+                AudioFileBinaryType.Binary => "binary",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static AudioFileBinaryType? ToEnum(string value)
+        {
+            return value switch
+            {
+                "binary" => AudioFileBinaryType.Binary,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.AudioFileUrl.Json.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioFileUrl.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Together
+{
+    public sealed partial class AudioFileUrl
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Together.AudioFileUrl? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Together.AudioFileUrl),
+                jsonSerializerContext) as global::Together.AudioFileUrl;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Together.AudioFileUrl? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Together.AudioFileUrl>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Together.AudioFileUrl?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Together.AudioFileUrl),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Together.AudioFileUrl;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Together.AudioFileUrl?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Together.AudioFileUrl?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.AudioFileUrl.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioFileUrl.g.cs
@@ -1,0 +1,56 @@
+
+#nullable enable
+
+namespace Together
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class AudioFileUrl
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("type")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Together.JsonConverters.AudioFileUrlTypeJsonConverter))]
+        public global::Together.AudioFileUrlType Type { get; set; }
+
+        /// <summary>
+        /// Public HTTPS URL to audio file
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("url")]
+        [global::System.Text.Json.Serialization.JsonRequired]
+        public required string Url { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioFileUrl" /> class.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="url">
+        /// Public HTTPS URL to audio file
+        /// </param>
+#if NET7_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
+        public AudioFileUrl(
+            string url,
+            global::Together.AudioFileUrlType type)
+        {
+            this.Url = url ?? throw new global::System.ArgumentNullException(nameof(url));
+            this.Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioFileUrl" /> class.
+        /// </summary>
+        public AudioFileUrl()
+        {
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.AudioFileUrlType.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioFileUrlType.g.cs
@@ -1,0 +1,45 @@
+
+#nullable enable
+
+namespace Together
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum AudioFileUrlType
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Url,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class AudioFileUrlTypeExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this AudioFileUrlType value)
+        {
+            return value switch
+            {
+                AudioFileUrlType.Url => "url",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static AudioFileUrlType? ToEnum(string value)
+        {
+            return value switch
+            {
+                "url" => AudioFileUrlType.Url,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.AudioTranscriptionRequest.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioTranscriptionRequest.g.cs
@@ -14,9 +14,9 @@ namespace Together
         /// Audio file upload or public HTTP/HTTPS URL. Supported formats .wav, .mp3, .m4a, .webm, .flac.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("file")]
-        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Together.JsonConverters.OneOfJsonConverter<byte[], string>))]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Together.JsonConverters.FileJsonConverter))]
         [global::System.Text.Json.Serialization.JsonRequired]
-        public required global::Together.OneOf<byte[], string> File { get; set; }
+        public required global::Together.File File { get; set; }
 
         /// <summary>
         /// Optional ISO 639-1 language code. If `auto` is provided, language is auto-detected.<br/>
@@ -107,7 +107,7 @@ namespace Together
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public AudioTranscriptionRequest(
-            global::Together.OneOf<byte[], string> file,
+            global::Together.File file,
             string? language,
             global::Together.AudioTranscriptionRequestModel? model,
             string? prompt,

--- a/src/libs/Together/Generated/Together.Models.AudioTranscriptionRequestFileDiscriminator.Json.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioTranscriptionRequestFileDiscriminator.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Together
+{
+    public sealed partial class AudioTranscriptionRequestFileDiscriminator
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Together.AudioTranscriptionRequestFileDiscriminator? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Together.AudioTranscriptionRequestFileDiscriminator),
+                jsonSerializerContext) as global::Together.AudioTranscriptionRequestFileDiscriminator;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Together.AudioTranscriptionRequestFileDiscriminator? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Together.AudioTranscriptionRequestFileDiscriminator>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Together.AudioTranscriptionRequestFileDiscriminator?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Together.AudioTranscriptionRequestFileDiscriminator),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Together.AudioTranscriptionRequestFileDiscriminator;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Together.AudioTranscriptionRequestFileDiscriminator?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Together.AudioTranscriptionRequestFileDiscriminator?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.AudioTranscriptionRequestFileDiscriminator.g.cs
+++ b/src/libs/Together/Generated/Together.Models.AudioTranscriptionRequestFileDiscriminator.g.cs
@@ -1,0 +1,43 @@
+
+#nullable enable
+
+namespace Together
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class AudioTranscriptionRequestFileDiscriminator
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioTranscriptionRequestFileDiscriminator" /> class.
+        /// </summary>
+        /// <param name="type"></param>
+#if NET7_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
+        public AudioTranscriptionRequestFileDiscriminator(
+            string? type)
+        {
+            this.Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioTranscriptionRequestFileDiscriminator" /> class.
+        /// </summary>
+        public AudioTranscriptionRequestFileDiscriminator()
+        {
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.File.Json.g.cs
+++ b/src/libs/Together/Generated/Together.Models.File.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Together
+{
+    public readonly partial struct File
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Together.File? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Together.File),
+                jsonSerializerContext) as global::Together.File?;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Together.File? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Together.File>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Together.File?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Together.File),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Together.File?;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Together.File?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Together.File?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Together/Generated/Together.Models.File.g.cs
+++ b/src/libs/Together/Generated/Together.Models.File.g.cs
@@ -1,0 +1,222 @@
+#pragma warning disable CS0618 // Type or member is obsolete
+
+#nullable enable
+
+namespace Together
+{
+    /// <summary>
+    /// Audio file upload or public HTTP/HTTPS URL. Supported formats .wav, .mp3, .m4a, .webm, .flac.
+    /// </summary>
+    public readonly partial struct File : global::System.IEquatable<File>
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        public global::Together.AudioFileBinary? AudioBinary { get; init; }
+#else
+        public global::Together.AudioFileBinary? AudioBinary { get; }
+#endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(AudioBinary))]
+#endif
+        public bool IsAudioBinary => AudioBinary != null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator File(global::Together.AudioFileBinary value) => new File((global::Together.AudioFileBinary?)value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator global::Together.AudioFileBinary?(File @this) => @this.AudioBinary;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public File(global::Together.AudioFileBinary? value)
+        {
+            AudioBinary = value;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        public global::Together.AudioFileUrl? AudioUrl { get; init; }
+#else
+        public global::Together.AudioFileUrl? AudioUrl { get; }
+#endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(AudioUrl))]
+#endif
+        public bool IsAudioUrl => AudioUrl != null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator File(global::Together.AudioFileUrl value) => new File((global::Together.AudioFileUrl?)value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator global::Together.AudioFileUrl?(File @this) => @this.AudioUrl;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public File(global::Together.AudioFileUrl? value)
+        {
+            AudioUrl = value;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public File(
+            global::Together.AudioFileBinary? audioBinary,
+            global::Together.AudioFileUrl? audioUrl
+            )
+        {
+            AudioBinary = audioBinary;
+            AudioUrl = audioUrl;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public object? Object =>
+            AudioUrl as object ??
+            AudioBinary as object 
+            ;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override string? ToString() =>
+            AudioBinary?.ToString() ??
+            AudioUrl?.ToString() 
+            ;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Validate()
+        {
+            return IsAudioBinary && !IsAudioUrl || !IsAudioBinary && IsAudioUrl;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public TResult? Match<TResult>(
+            global::System.Func<global::Together.AudioFileBinary?, TResult>? audioBinary = null,
+            global::System.Func<global::Together.AudioFileUrl?, TResult>? audioUrl = null,
+            bool validate = true)
+        {
+            if (validate)
+            {
+                Validate();
+            }
+
+            if (IsAudioBinary && audioBinary != null)
+            {
+                return audioBinary(AudioBinary!);
+            }
+            else if (IsAudioUrl && audioUrl != null)
+            {
+                return audioUrl(AudioUrl!);
+            }
+
+            return default(TResult);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void Match(
+            global::System.Action<global::Together.AudioFileBinary?>? audioBinary = null,
+            global::System.Action<global::Together.AudioFileUrl?>? audioUrl = null,
+            bool validate = true)
+        {
+            if (validate)
+            {
+                Validate();
+            }
+
+            if (IsAudioBinary)
+            {
+                audioBinary?.Invoke(AudioBinary!);
+            }
+            else if (IsAudioUrl)
+            {
+                audioUrl?.Invoke(AudioUrl!);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override int GetHashCode()
+        {
+            var fields = new object?[]
+            {
+                AudioBinary,
+                typeof(global::Together.AudioFileBinary),
+                AudioUrl,
+                typeof(global::Together.AudioFileUrl),
+            };
+            const int offset = unchecked((int)2166136261);
+            const int prime = 16777619;
+            static int HashCodeAggregator(int hashCode, object? value) => value == null
+                ? (hashCode ^ 0) * prime
+                : (hashCode ^ value.GetHashCode()) * prime;
+
+            return global::System.Linq.Enumerable.Aggregate(fields, offset, HashCodeAggregator);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Equals(File other)
+        {
+            return
+                global::System.Collections.Generic.EqualityComparer<global::Together.AudioFileBinary?>.Default.Equals(AudioBinary, other.AudioBinary) &&
+                global::System.Collections.Generic.EqualityComparer<global::Together.AudioFileUrl?>.Default.Equals(AudioUrl, other.AudioUrl) 
+                ;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static bool operator ==(File obj1, File obj2)
+        {
+            return global::System.Collections.Generic.EqualityComparer<File>.Default.Equals(obj1, obj2);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static bool operator !=(File obj1, File obj2)
+        {
+            return !(obj1 == obj2);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override bool Equals(object? obj)
+        {
+            return obj is File o && Equals(o);
+        }
+    }
+}

--- a/src/libs/Together/openapi.yaml
+++ b/src/libs/Together/openapi.yaml
@@ -2103,6 +2103,34 @@ paths:
           source: "curl \"https://api.together.xyz/v1/tci/sessions\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\"\n"
 components:
   schemas:
+    AudioFileBinary:
+      required:
+        - type
+        - data
+      type: object
+      properties:
+        data:
+          type: string
+          description: Audio file to transcribe
+          format: binary
+        type:
+          enum:
+            - binary
+          type: string
+    AudioFileUrl:
+      required:
+        - type
+        - url
+      type: object
+      properties:
+        type:
+          enum:
+            - url
+          type: string
+        url:
+          type: string
+          description: Public HTTPS URL to audio file
+          format: uri
     AudioSpeechRequest:
       required:
         - model
@@ -2220,13 +2248,11 @@ components:
       properties:
         file:
           oneOf:
-            - type: string
-              description: Audio file to transcribe
-              format: binary
-            - type: string
-              description: Public HTTP/HTTPS URL to audio file
-              format: uri
+            - $ref: '#/components/schemas/AudioFileBinary'
+            - $ref: '#/components/schemas/AudioFileUrl'
           description: 'Audio file upload or public HTTP/HTTPS URL. Supported formats .wav, .mp3, .m4a, .webm, .flac.'
+          discriminator:
+            propertyName: type
         language:
           type: string
           description: 'Optional ISO 639-1 language code. If `auto` is provided, language is auto-detected.'


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now provide audio input as either a binary file upload or a URL, with clear type selection.
- Refactor
  - Audio input options are now standardized using distinct types for easier validation and integration.
  - The text input field in audio speech requests is no longer required, allowing requests with audio-only input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->