### PR TITLE
feat:Update x-codeSamples to Meta-Llama-3.1-8B and add max_tokens: 1

### DIFF
--- a/src/libs/Together/openapi.yaml
+++ b/src/libs/Together/openapi.yaml
@@ -468,16 +468,16 @@ paths:
       x-codeSamples:
         - label: Together AI SDK (Python)
           lang: Python
-          source: "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.completions.create(\n    model=\"meta-llama/Llama-2-70b-hf\",\n    prompt=\"The largest city in France is\",\n)\n\nprint(response.choices[0].text)\n"
+          source: "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.completions.create(\n    model=\"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo\",\n    prompt=\"The largest city in France is\",\n    max_tokens=1\n)\n\nprint(response.choices[0].text)\n"
         - label: Together AI SDK (TypeScript)
           lang: TypeScript
-          source: "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.completions.create({\n  model: \"meta-llama/Llama-2-70b-hf\",\n  prompt: \"The largest city in France is\",\n});\n\nconsole.log(response.choices[0].text);\n"
+          source: "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.completions.create({\n  model: \"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo\",\n  prompt: \"The largest city in France is\",\n  max_tokens: 1\n});\n\nconsole.log(response.choices[0].text);\n"
         - label: Together AI SDK (JavaScript)
           lang: JavaScript
-          source: "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.completions.create({\n  model: \"meta-llama/Llama-2-70b-hf\",\n  prompt: \"The largest city in France is\",\n});\n\nconsole.log(response.choices[0].text);\n"
+          source: "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.completions.create({\n  model: \"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo\",\n  prompt: \"The largest city in France is\",\n  max_tokens: 1\n});\n\nconsole.log(response.choices[0].text);\n"
         - label: cURL
           lang: Shell
-          source: "curl -X POST \"https://api.together.xyz/v1/completions\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"meta-llama/Llama-2-70b-hf\",\n       \"prompt\": \"The largest city in France is\"\n     }'\n"
+          source: "curl -X POST \"https://api.together.xyz/v1/completions\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo\",\n       \"prompt\": \"The largest city in France is\",\n       \"max_tokens\": 1\n     }'\n"
   /embeddings:
     post:
       tags:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated code samples to use the model Meta-Llama-3.1-8B-Instruct-Turbo instead of Llama-2-70b across Python, TypeScript, JavaScript, and cURL.
  * Added max_tokens: 1 to all completions examples to illustrate constrained output.
  * Refreshed chat completions examples with the new model reference; no other behavioral changes.
  * No API endpoints or schemas were changed; updates are limited to example snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->