### PR TITLE
feat:Add optional nullable 'reasoning' to ChatCompletion response schemas

### DIFF
--- a/src/libs/Together/Generated/Together.Models.ChatCompletionChoiceDelta.g.cs
+++ b/src/libs/Together/Generated/Together.Models.ChatCompletionChoiceDelta.g.cs
@@ -24,6 +24,12 @@ namespace Together
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("reasoning")]
+        public string? Reasoning { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("role")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Together.JsonConverters.ChatCompletionChoiceDeltaRoleJsonConverter))]
         [global::System.Text.Json.Serialization.JsonRequired]
@@ -51,6 +57,7 @@ namespace Together
         /// Initializes a new instance of the <see cref="ChatCompletionChoiceDelta" /> class.
         /// </summary>
         /// <param name="content"></param>
+        /// <param name="reasoning"></param>
         /// <param name="role"></param>
         /// <param name="tokenId"></param>
         /// <param name="toolCalls"></param>
@@ -60,11 +67,13 @@ namespace Together
         public ChatCompletionChoiceDelta(
             global::Together.ChatCompletionChoiceDeltaRole role,
             string? content,
+            string? reasoning,
             int? tokenId,
             global::System.Collections.Generic.IList<global::Together.ToolChoice2>? toolCalls)
         {
             this.Role = role;
             this.Content = content;
+            this.Reasoning = reasoning;
             this.TokenId = tokenId;
             this.ToolCalls = toolCalls;
         }

--- a/src/libs/Together/Generated/Together.Models.ChatCompletionMessage.g.cs
+++ b/src/libs/Together/Generated/Together.Models.ChatCompletionMessage.g.cs
@@ -25,6 +25,12 @@ namespace Together
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("reasoning")]
+        public string? Reasoning { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("role")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Together.JsonConverters.ChatCompletionMessageRoleJsonConverter))]
         public global::Together.ChatCompletionMessageRole Role { get; set; }
@@ -45,6 +51,7 @@ namespace Together
         /// Initializes a new instance of the <see cref="ChatCompletionMessage" /> class.
         /// </summary>
         /// <param name="content"></param>
+        /// <param name="reasoning"></param>
         /// <param name="role"></param>
         /// <param name="toolCalls"></param>
 #if NET7_0_OR_GREATER
@@ -52,10 +59,12 @@ namespace Together
 #endif
         public ChatCompletionMessage(
             string? content,
+            string? reasoning,
             global::Together.ChatCompletionMessageRole role,
             global::System.Collections.Generic.IList<global::Together.ToolChoice2>? toolCalls)
         {
             this.Content = content ?? throw new global::System.ArgumentNullException(nameof(content));
+            this.Reasoning = reasoning;
             this.Role = role;
             this.ToolCalls = toolCalls;
         }

--- a/src/libs/Together/openapi.yaml
+++ b/src/libs/Together/openapi.yaml
@@ -2685,6 +2685,9 @@ components:
                   type: string
               nullable: true
               deprecated: true
+            reasoning:
+              type: string
+              nullable: true
             role:
               enum:
                 - system
@@ -2848,6 +2851,9 @@ components:
             name:
               type: string
           deprecated: true
+        reasoning:
+          type: string
+          nullable: true
         role:
           enum:
             - assistant


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat completion responses may now include an optional reasoning field in both full messages and streaming deltas. This field is nullable and only present when available.
  * No breaking changes: existing integrations continue to work unchanged.
  * Clients can optionally read and display reasoning content to enhance transparency, diagnostics, or UX where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->