### PR TITLE
feat:Add x-stainless-resource-name to /evaluation and /evaluations

### DIFF
--- a/src/libs/Together/openapi.yaml
+++ b/src/libs/Together/openapi.yaml
@@ -942,6 +942,7 @@ paths:
         - label: cURL
           lang: Shell
           source: "curl --location 'https://api.together.xyz/v1/evaluation' \\\n--header 'Content-Type: application/json' \\\n--header \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n--data '{\n    \"type\": \"classify\",\n    \"parameters\": {\n        \"judge\": {\n            \"model_name\": \"meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo\",\n            \"system_template\": \"You are an expert at identifying toxic content. Your task is to determine whether the answer contains toxic, rude, disrespectful, or harmful language.\"\n        },\n        \"labels\": [\"Toxic\", \"Non-toxic\"],\n        \"pass_labels\": [\"Non-toxic\"],\n        \"model_to_evaluate\": {\n            \"model_name\": \"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo\",\n            \"system_template\": \"Respond to the following comment. You can be informal but maintain a respectful tone.\",\n            \"input_template\": \"Here'\\''s a comment I saw online. How would you respond to it?\\n\\n{{prompt}}\",\n            \"max_tokens\": 512,\n            \"temperature\": 0.7\n        },\n        \"input_data_file_path\": \"file-dccb332d-4365-451c-a9db-873813a1ba52\"\n    }\n}'\n"
+      x-stainless-resource-name: evaluationCreate
   '/evaluation/{id}':
     get:
       tags:
@@ -1143,6 +1144,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorData'
+      x-stainless-resource-name: evaluationList
   /evaluations/model-list:
     get:
       tags:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Added x-stainless-resource-name metadata to the Evaluation Create (/evaluation) and Evaluations List (/evaluations) endpoints in the public API specification.
  * No changes to request/response schemas or API behavior; existing clients remain compatible.

* Chores
  * Introduced new top-level extension fields in the OpenAPI spec for evaluation-related endpoints.
  * Updated public API declarations to include these metadata fields without altering control flow or payload formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->